### PR TITLE
Add `Statement.type` and use MediaType in envelope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pretending they were built on
 
 ```json
 {
-  "payloadType": "https://in-toto.io/Statement/v1-json",
+  "payloadType": "application/vnd.in-toto+json",
   "payload": "ewogICJzdWJqZWN0IjogWwogICAg...",
   "signatures": [{"sig": "MeQyap6MyFyc9Y..."}]
 }
@@ -91,6 +91,7 @@ where `payload` base64-decodes as the following [Statement]:
 
 ```json
 {
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [
     { "name": "curl-7.72.0.tar.bz2",
       "digest": { "sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef" }},
@@ -165,6 +166,7 @@ command. The existing [Link] schema has little benefit. Instead, a custom
 
 ```json
 {
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [
     { "digest": { "sha1":  "859b387b985ea0f414e4e8099c9f874acb217b94" } }
   ],
@@ -187,6 +189,7 @@ better fit:
 
 ```json
 {
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [
     { "digest": { "sha1": "859b387b985ea0f414e4e8099c9f874acb217b94" } }
   ],

--- a/spec/README.md
+++ b/spec/README.md
@@ -27,7 +27,7 @@ See the [top-level README](../README.md) for background and examples.
 
 ```jsonc
 {
-  "payloadType": "https://in-toto.io/Statement/v1-json",
+  "payloadType": "application/vnd.in-toto+json",
   "payload": "<Base64(Statement)>",
   "signatures": [{"sig": "<Base64(Signature)>"}]
 }
@@ -39,22 +39,24 @@ adopted by in-toto in [ITE-5]. It is a [JSON] object with the following fields:
 
 `payloadType` *string, required*
 
->   Always `https://in-toto.io/Statement/v1-json` (for the [Statement] defined
->   below).
+> Identifier for the encoding of the payload. Always
+> `application/vnd.in-toto+json`, which indicates that it is a JSON object with
+> a `type` field indicating its schema.
 
 `payload` *string, required*
 
->   Base64-encoded JSON [Statement].
+> Base64-encoded JSON [Statement].
 
 `signatures` *array of objects, required*
 
->   One or more signatures over `payloadType` and `payload`, as defined in
->   [signing-spec].
+> One or more signatures over `payloadType` and `payload`, as defined in
+> [signing-spec].
 
 ## Statement
 
 ```jsonc
 {
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [
     {
       "name": "<NAME>",
@@ -70,6 +72,11 @@ adopted by in-toto in [ITE-5]. It is a [JSON] object with the following fields:
 The Statement is the middle layer of the attestation, binding it to a particular
 subject and unambiguously identifying the types of the [predicate]. It is a
 [JSON] object with the following fields:
+
+`type` _string ([TypeURI]), required_
+
+> Identifier for the schema of the Statement. Always
+> `https://in-toto.io/Statement/v1`.
 
 `subject` _array of objects, required_
 
@@ -195,10 +202,10 @@ Steps:
 *   Intermediate state: `envelope.payloadType`, `envelope.payload`,
     `attesterNames`
 *   Statement layer:
-    *   Reject if `envelope.payloadType` !=
-        `https://in-toto.io/Attestation/v1-json`
+    *   Reject if `envelope.payloadType` != `application/vnd.in-toto+json`
     *   `statement` := decode `envelope.payload` as a JSON-encoded [Statement];
         reject if decoding fails
+    *   Reject if `statement.type` != `https://in-toto.io/Statement/v1`
     *   `artifactNames` := empty set of names
     *   For each `s` in `statement.subject`:
         *   For each digest (`alg`, `value`) in `s.digest`:

--- a/spec/field_types.md
+++ b/spec/field_types.md
@@ -55,7 +55,7 @@ _TypeURI (string)_
 > TypeURIs are not registered. The natural namespacing of URIs is sufficient to
 > prevent collisions.
 >
-> Example: `"https://in-toto.io/Attestation/v1"`.
+> Example: `"https://in-toto.io/Statement/v1"`.
 
 <a id="Timestamp"></a>
 _Timestamp (string)_

--- a/spec/predicates/link.md
+++ b/spec/predicates/link.md
@@ -15,7 +15,11 @@ Most users should migrate to a more specific attestation type, such as
 
 ```jsonc
 {
+  // Standard attestation fields:
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [{ ... }],
+
+  // Predicate:
   "predicateType": "https://in-toto.io/Link/v1",
   "predicate": {
     "_type": "link",

--- a/spec/predicates/provenance.md
+++ b/spec/predicates/provenance.md
@@ -12,7 +12,11 @@ The primary focus is on automated builds that followed some "recipe".
 
 ```jsonc
 {
+  // Standard attestation fields:
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [{ ... }],
+
+  // Predicate:
   "predicateType": "https://in-toto.io/Provenance/v1",
   "predicate": {                           // required
     "builder": {                           // required
@@ -46,6 +50,12 @@ _(Note: This is a Predicate type that fits within the larger
 [Attestation](../README.md) framework.)_
 
 ### Fields
+
+<a id="type"></a>
+`type` _string ([TypeURI]), required_
+
+> Standard [Predicate](../README.md#predicate) field. Always
+> `https://in-toto.io/Provenance/v1`.
 
 <a id="builder"></a>
 `builder` _object, required_

--- a/spec/predicates/spdx.md
+++ b/spec/predicates/spdx.md
@@ -12,13 +12,17 @@ A Software Bill of Materials type following the
 
 This allows to represent an "exportable" or "published" software artifact. It
 can also be used as an entry point for other types of in-toto attestation when
-performing policy decisions
+performing policy decisions.
 
 ## Schema
 
 ```jsonc
 {
+  // Standard attestation fields:
+  "type": "https://in-toto.io/Statement/v1",
   "subject": [{ ... }],
+
+  // Predicate:
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID" : "SPDXRef-DOCUMENT",


### PR DESCRIPTION
## Current description

Add a new Statement `type` field that indicates the schema version,
and use an unversioned MediaType in the Envelope `payloadType` field.

Reasoning:

-   This makes the Statement self-describing, which aids readability.
-   Not all envelopes authenticate the payload type. Since we want the
    layers to be independent, we should include the schema version
    inside to protect against this.
-   MediaType is the standard way of indicating encoding; URI is
    uncommon for that purpose.
-   Most formats include a version inside the payload (e.g. PDF or
    JsonSchema) and have an unversioned MediaType. We do the same.
-   Removing the encoding from the type URI (i.e. removing "-json")
    allows policy engines to be encoding-agnostic.
-   The existing in-toto format (link and layout) already use a `type`
    field, so we can continue using the same concise MediaType.

Note that the same reasoning does *not* apply to `predicateType`, which
continues to be a URI. We considered moving it inside `predicate.type`,
but then we need to worry about field name collisions.


## Original description (obsolete)

Make each layer define its own schema via a standard `type` field,
rather than relying on the outer layer to specify it. This way each
layer is not dependent on the outer layers. Now, for example, the
definition of Predicate is much simpler: it is a JSON object with a
`type` field, not a combination of `predicateType` + `predicate`.

Another minor advantage is that the encoding (e.g. JSON) is independent
of the schema (e.g. v1). This can simplify consumers' logic.