### PR TITLE
Add rekord type from sigstore/rekor

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -15,6 +15,7 @@ independent but designed to work together:
     *   [Provenance]: To describe the origins of a software artifact.
     *   [Link]: For migration from [in-toto 0.9].
     *   [SPDX]: A Software Package Data Exchange document.
+    *   [Rekord]: Recording signed metadata
 
 The [processing model] provides pseudocode showing how these layers fit
 together.

--- a/spec/README.md
+++ b/spec/README.md
@@ -15,7 +15,7 @@ independent but designed to work together:
     *   [Provenance]: To describe the origins of a software artifact.
     *   [Link]: For migration from [in-toto 0.9].
     *   [SPDX]: A Software Package Data Exchange document.
-    *   [Rekord]: Recording signed metadata
+    *   [Rekord](predicate/rekord.md): Recording signed metadata
 
 The [processing model] provides pseudocode showing how these layers fit
 together.

--- a/spec/README.md
+++ b/spec/README.md
@@ -138,6 +138,7 @@ This repo defines the following predicate types:
 *   [Provenance]: To describe the origins of a software artifact.
 *   [Link]: For migration from [in-toto 0.9].
 *   [SPDX]: A Software Package Data Exchange document.
+*   [Rekord](predicate/rekord.md): Recording signed metadata
 
 ### Predicate conventions
 

--- a/spec/predicates/rekord.md
+++ b/spec/predicates/rekord.md
@@ -1,0 +1,26 @@
+# Predicate type: Rekord v1
+
+Type URI: https://sigstore.dev/Rekord
+
+## Purpose
+Support for the sigstore's [rekord type](https://github.com/sigstore/rekor). Rekord is a default type for the rekor, which enables software maintainers and build systems to record signed metadata to an immutable record.
+
+## Schema
+
+```jsonc
+{
+  "subject": [{ ... }],
+  "predicateType": "https://sigstore.dev/Rekord", // or https://rekord.sigstore.dev/Rekord - is there already a pre-defined URI?
+  "predicate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://rekor.sigstore.dev/types/rekord/rekord_schema.json",
+    "title": "Rekor Schema",
+    "description": "Schema for Rekord objects",
+    "type": "object",
+    "oneOf": [
+        {
+            "$ref": "v0.0.1/rekord_v0_0_1_schema.json"
+        }
+    ]
+  }
+}


### PR DESCRIPTION
Re: in-toto community meeting, where we discussed adding the schema of the rekord type in ITE6 for more general link formats.

Not fully sure if putting it in predicate is the right place, but it looks like the rekord type contains metadata that we want to accept and pass along, and because that falls under the Predicate part of the attestation (from my understanding), I added the schema in that folder. 

Some questions/clarifications:
- Is there already a pre-existing URI for rekord, and where would I find it? I looked at the other links such as SPDX which seem to be not actual links and just something that made up to differentiate the resources. RFC 3986 also states "A Uniform Resource Identifier (URI) is a compact sequence of characters that identifies an abstract or physical resource." At the same time, what are the official naming conventions (aside from the upper/lowercase rules + the v1/v2 if we may want to update) and where are these URIs stored? I tried looking up some of the URIs we already have but couldn't find where or how we came across those.
- When is "v1" for predicate types used and when is it not used (just the predicate type name)?
- Since these are documentation in the spec, where are we enforcing these types (or WIP for now?)