### PR TITLE
Document convention for versioning and extensions, remove mediaType and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,22 +116,15 @@ where `payload` base64-decodes as the following [Statement]:
     "materials": [
       {
         "uri": "git+https://github.com/curl/curl-docker@master",
-        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" },
-        "mediaType": "application/vnd.git.commit",
-        "tags": ["source"]
+        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" }
       }, {
-        "uri": "github_hosted_vm:ubuntu-18.04:20210123.1",
-        "tags": ["base-image"]
+        "uri": "github_hosted_vm:ubuntu-18.04:20210123.1"
       }, {
         "uri": "git+https://github.com/actions/checkout@v2",
-        "digest": {"sha1": "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f"},
-        "mediaType": "application/vnd.git.commit",
-        "tags": ["dev-dependency"]
+        "digest": {"sha1": "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f"}
       }, {
         "uri": "git+https://github.com/actions/upload-artifact@v2",
-        "digest": { "sha1": "e448a9b857ee2131e752b06002bf0e093c65e571" },
-        "mediaType": "application/vnd.git.commit",
-        "tags": ["dev-dependency"]
+        "digest": { "sha1": "e448a9b857ee2131e752b06002bf0e093c65e571" }
       }, {
         "uri": "pkg:deb/debian/stunnel4@5.50-3?arch=amd64",
         "digest": { "sha256": "e1731ae217fcbc64d4c00d707dcead45c828c5f762bcf8cc56d87de511e096fa" }

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,24 +23,35 @@ together.
 
 See the [top-level README](../README.md) for background and examples.
 
-## Versioning and extensions
+## Parsing rules
 
-Consumers MUST ignore unrecognized fields.
+*   **Unrecognized fields:** Consumers MUST ignore unrecognized fields.
 
-Each type has a [SemVer2](https://semver.org) version number and the [TypeURI]
-reflects the major version number. A message is semantically correct, but
-possibly incomplete, when parsed as any other version with the same major
-version number (and thus the same [TypeURI]). For example, if version 1.0.0 has
-a field `foo` and version 1.1.0 adds a field `bar`, then parsing a 1.0 message
-as 1.1 says no information about `bar`, and parsing a 1.1 message as 1.0 ignores
-information about `bar`, but in both cases information about `foo` is valid.
-(See [versioning rules](versioning.md) for details.)
+*   **Versioning:** Each type has a [SemVer2](https://semver.org) version number
+    and the [TypeURI] reflects the major version number. A message is
+    semantically correct, but possibly incomplete, when parsed as any other
+    version with the same major version number (and thus the same [TypeURI]).
+    For example, if version 1.0.0 has a field `foo` and version 1.1.0 adds a
+    field `bar`, then parsing a 1.0 message as 1.1 says no information about
+    `bar`, and parsing a 1.1 message as 1.0 ignores information about `bar`, but
+    in both cases information about `foo` is valid. (See
+    [versioning rules](versioning.md) for details.)
 
-Producers MAY add extension fields to any JSON object by using a property name
-that is a [TypeURI]. Example: `{"materials":
-[{"https://example.com/Awesomeness": 99, ...}]}`. The use of URI is to protect
-against name collisions. Consumers MAY parse and use these extensions if
-desired.
+*   **Extension fields:** Producers MAY add extension fields to any JSON object
+    by using a property name that is a [TypeURI]. The use of URI is to protect
+    against name collisions. Consumers MAY parse and use these extensions if
+    desired.
+
+    Example: A hypothetical "tags" extension may annotate the type of each
+    material in [Provenance]:
+
+    ```jsonc
+    "materials": [{
+      "uri": "...",
+      "digest": {...},
+      "https://example.com/tags": ["dev-dependency"]
+    }]
+    ```
 
 ## Envelope
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,6 +23,25 @@ together.
 
 See the [top-level README](../README.md) for background and examples.
 
+## Versioning and extensions
+
+Consumers MUST ignore unrecognized fields.
+
+Each type has a [SemVer2](https://semver.org) version number and the [TypeURI]
+reflects the major version number. A message is semantically correct, but
+possibly incomplete, when parsed as any other version with the same major
+version number (and thus the same [TypeURI]). For example, if version 1.0.0 has
+a field `foo` and version 1.1.0 adds a field `bar`, then parsing a 1.0 message
+as 1.1 says no information about `bar`, and parsing a 1.1 message as 1.0 ignores
+information about `bar`, but in both cases information about `foo` is valid.
+(See [versioning rules](versioning.md) for details.)
+
+Producers MAY add extension fields to any JSON object by using a property name
+that is a [TypeURI]. Example: `{"materials":
+[{"https://example.com/Awesomeness": 99, ...}]}`. The use of URI is to protect
+against name collisions. Consumers MAY parse and use these extensions if
+desired.
+
 ## Envelope
 
 ```jsonc

--- a/spec/README.md
+++ b/spec/README.md
@@ -99,6 +99,8 @@ adopted by in-toto in [ITE-5]. It is a [JSON] object with the following fields:
 }
 ```
 
+Version: 0.1.0
+
 The Statement is the middle layer of the attestation, binding it to a particular
 subject and unambiguously identifying the types of the [predicate]. It is a
 [JSON] object with the following fields:

--- a/spec/predicates/link.md
+++ b/spec/predicates/link.md
@@ -1,6 +1,8 @@
-# Predicate type: Link v1
+# Predicate type: Link
 
 Type URI: https://in-toto.io/Link/v1
+
+Version: 1.0.0
 
 ## Purpose
 

--- a/spec/predicates/provenance.md
+++ b/spec/predicates/provenance.md
@@ -69,6 +69,10 @@ See [Example](#example) for a concrete example.
 _(Note: This is a Predicate type that fits within the larger
 [Attestation](../README.md) framework.)_
 
+### Parsing rules
+
+See [parsing rules](../README.md#parsing-rules).
+
 ### Fields
 
 <a id="type"></a>

--- a/spec/predicates/provenance.md
+++ b/spec/predicates/provenance.md
@@ -1,6 +1,8 @@
-# Predicate type: Provenance v0.1
+# Predicate type: Provenance
 
 Type URI: https://in-toto.io/Provenance/v0.1
+
+Version: 0.1.0
 
 ## Purpose
 

--- a/spec/predicates/provenance.md
+++ b/spec/predicates/provenance.md
@@ -59,9 +59,7 @@ See [Example](#example) for a concrete example.
     "materials": [
       {
         "uri": "<URI>",
-        "digest": { /* DigestSet */ },
-        "mediaType": "<MEDIA_TYPE>",
-        "tags": [ "<STRING>" ]
+        "digest": { /* DigestSet */ }
       }
     ]
   }
@@ -252,20 +250,6 @@ _(Note: This is a Predicate type that fits within the larger
 `materials[*].digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of this artifact.
-
-<a id="materials.mediaType"></a>
-`materials[*].mediaType` _string (Media Type), optional_
-
-> The [Media Type](https://www.iana.org/assignments/media-types/) for this
-> artifact, if known.
-
-<a id="materials.tags"></a>
-`materials[*].tags` _array (of strings), optional_
-
-> Unordered set of labels whose meaning is dependent on `recipe.type`. SHOULD be
-> sorted lexicographically.
->
-> TODO: Recommend specific conventions, e.g. `source` and `dev-dependency`.
 
 ## Example
 

--- a/spec/predicates/spdx.md
+++ b/spec/predicates/spdx.md
@@ -2,6 +2,8 @@
 
 Type URI: (tentative) https://spdx.dev/Document
 
+Version: 1.0.0
+
 TODO: Ask SPDX project to choose a URI and to review this spec. Ideally the URI
 would resolve to this file.
 

--- a/spec/versioning.md
+++ b/spec/versioning.md
@@ -27,7 +27,7 @@ the same major number. That is:
 
 The type ID only includes the major version. This allows implementations to
 support any major version without having to parse the URI to pull out the
-version. (Parsing is possible since we don't mandate the format of the URI.)
+version. (Parsing is impossible since we don't mandate the format of the URI.)
 Implementations just use the URI as an opaque string.
 
 The advantage of having minor versions is that we can add new information

--- a/spec/versioning.md
+++ b/spec/versioning.md
@@ -1,0 +1,48 @@
+# Versioning Rules
+
+## Objective
+
+This document explains how to update the version number when making changes to
+the spec. For regular consumers of the spec, see
+[README](README.md#versioning-and-extensions).
+
+## Versioning rules
+
+We adhere to [Semantic Versioning 2.0.0](https://semver.org), i.e.
+MAJOR.MINOR.PATCH. (PATCH isn't really needed, but we do it just so we're SemVer
+compliant.) This way implementations can state specifically which version they
+support.
+
+Any message MUST be semantically correct when parsed as any other version with
+the same major number. That is:
+
+-   Parsing an older message as a newer minor/patch version MUST be semantically
+    equivalent to parsing it as the original version. (All fields present in
+    both versions have the same meaning, and the absence of any new fields has
+    no semantic meaning.)
+-   Parsing a newer message as an older minor/patch version MUST be semantically
+    equivalent to parsing it as the newer version with all new fields removed.
+    (All fields present in both version have the same meaning, regardless of the
+    presence or absence of the new fields.)
+
+The type ID only includes the major version. This allows implementations to
+support any major version without having to parse the URI to pull out the
+version. (Parsing is possible since we don't mandate the format of the URI.)
+Implementations just use the URI as an opaque string.
+
+The advantage of having minor versions is that we can add new information
+without requiring consumers to update.
+
+## Examples
+
+-   Provenance 1.1.0 (minor version) adds a new `buildFinished` timestamp. This
+    is OK because the absence of the `buildFinished` has no semantic meaning and
+    the presence or absence of `buildFinished` does not affect the rest of the
+    message. The type ID is still `https://in-toto.io/Provenance/v1`.
+
+-   Provenance 2.0.0 (major version) adds a new `recipe.extraArgs` field. This
+    is required because the meaning of `recipe` changes if `extraArgs` is
+    present. Parsing it as 1.x.y will result in an incorrect interpretation.
+
+-   Provenance 3.0.0 (major version) modifies the meaning of `builder.id`. This
+    is required because an existing field was modified.

--- a/spec/versioning.md
+++ b/spec/versioning.md
@@ -4,7 +4,7 @@
 
 This document explains how to update the version number when making changes to
 the spec. For regular consumers of the spec, see
-[README](README.md#versioning-and-extensions).
+[README](README.md#parsing-rules).
 
 ## Versioning rules
 

--- a/spec/versioning.md
+++ b/spec/versioning.md
@@ -2,9 +2,8 @@
 
 ## Objective
 
-This document explains how to update the version number when making changes to
-the spec. For regular consumers of the spec, see
-[README](README.md#parsing-rules).
+This document explains how version changes and extension fields are handled. For
+a summary, see [parsing rules](README.md#parsing-rules) in the README.
 
 ## Versioning rules
 
@@ -33,7 +32,15 @@ Implementations just use the URI as an opaque string.
 The advantage of having minor versions is that we can add new information
 without requiring consumers to update.
 
+## Extension fields
+
+An extension field is a JSON object property whose key is a [TypeURI]. Producers
+MAY add such fields so long as they follow the same rules as adding a field to a
+new minor version.
+
 ## Examples
+
+Version changes:
 
 -   Provenance 1.1.0 (minor version) adds a new `buildFinished` timestamp. This
     is OK because the absence of the `buildFinished` has no semantic meaning and
@@ -46,3 +53,32 @@ without requiring consumers to update.
 
 -   Provenance 3.0.0 (major version) modifies the meaning of `builder.id`. This
     is required because an existing field was modified.
+
+Extension fields:
+
+-   A hypothetical "tags" extension might annotate the type of each material in
+    Provenance. This is OK (monotonic) because ignoring the field does not
+    affect any other field and is not expected to result in an ALLOW decision:
+
+    ```jsonc
+    "materials": [{
+      "uri": "...",
+      "digest": {...},
+      "https://example.com/tags": ["dev-dependency"]
+    }]
+    ```
+
+    A future minor version could potentially standardize that field, if it
+    becomes widely used.
+
+-   The following example is NOT OK because it is not monotonic, for the same
+    reason that `extraArgs` above requires a major version bump.
+
+    ```jsonc
+    "recipe": {
+      ...,
+      "https://example.com/extraArgs": {...}  // BAD
+    }
+    ```
+
+[TypeURI]: field_types.md#TypeURI


### PR DESCRIPTION
* Document the versioning convention (#4).
* Provide an extension mechanism based on URI-named fields (#8).
* State that consumers MUST ignore unrecognized fields, which is required by both of the above.
* Remove `mediaType` and `tags` from the Predicate spec since those two fields are not yet ready to be standardized (#19).

@TomHennen to review