### PR TITLE
Add a Null predicate type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [spec/README.md](spec/README.md). Summary:
     *   [Provenance]: To describe the origins of a software artifact.
     *   [Link]: For migration from [in-toto 0.9].
     *   [SPDX]: A Software Package Data Exchange document.
+    *   [Null]: May be used to describe a predicate-less attestation.
 
 The [processing model] provides pseudocode showing how these layers fit
 together.
@@ -300,6 +301,7 @@ keying primarily by resource name, in addition to content hash.
 [Envelope]: spec/README.md#envelope
 [ITE-6]: https://github.com/in-toto/ITE/pull/15
 [Link]: spec/predicates/link.md
+[Null]: spec/predicates/null.md
 [Predicate]: spec/README.md#predicate
 [Provenance]: spec/predicates/provenance.md
 [SLSA Attestation Model]: https://github.com/slsa-framework/slsa-controls/blob/main/attestations.md

--- a/spec/README.md
+++ b/spec/README.md
@@ -15,6 +15,7 @@ independent but designed to work together:
     *   [Provenance]: To describe the origins of a software artifact.
     *   [Link]: For migration from [in-toto 0.9].
     *   [SPDX]: A Software Package Data Exchange document.
+    *   [Null]: May be used to describe a predicate-less attestation.
 
 The [processing model] provides pseudocode showing how these layers fit
 together.
@@ -144,6 +145,7 @@ This repo defines the following predicate types:
 *   [Provenance]: To describe the origins of a software artifact.
 *   [Link]: For migration from [in-toto 0.9].
 *   [SPDX]: A Software Package Data Exchange document.
+*   [Null]: May be used to describe a predicate-less attestation.
 
 ### Predicate conventions
 
@@ -226,6 +228,7 @@ Output (to be fed into policy engine):
 [ITE-5]: https://github.com/in-toto/ITE/pull/13
 [JSON]: https://www.json.org
 [Link]: predicates/link.md
+[Null]: predicates/null.md
 [Predicate]: #predicate
 [Provenance]: predicates/provenance.md
 [RFC 3339]: https://tools.ietf.org/html/rfc3339

--- a/spec/predicates/null.md
+++ b/spec/predicates/null.md
@@ -1,6 +1,6 @@
 # Predicate type: Null
 
-Type URI: https://in-toto.io/Null
+Type URI: https://in-toto.io/Null/v1
 
 Version: 1.0.0
 
@@ -18,7 +18,7 @@ traditional code signing, where the notion of a predicate does not exist.
   "subject": [{ ... }],
 
   // Predicate:
-  "predicateType": "https://in-toto.io/Null",
+  "predicateType": "https://in-toto.io/Null/v1",
   "predicate": null  // or unset
 }
 ```

--- a/spec/predicates/null.md
+++ b/spec/predicates/null.md
@@ -1,0 +1,29 @@
+# Predicate type: Null
+
+Type URI: https://in-toto.io/Null
+
+Version: 1.0.0
+
+## Purpose
+
+Denotes the absense of a predicate. May be used as a drop-in replacement for
+traditional code signing, where the notion of a predicate does not exist.
+
+## Schema
+
+```jsonc
+{
+  // Standard attestation fields:
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [{ ... }],
+
+  // Predicate:
+  "predicateType": "https://in-toto.io/Null",
+  "predicate": null  // or unset
+}
+```
+
+_(Note: This is a Predicate type that fits within the larger
+[Attestation](../README.md) framework.)_
+
+This predicate has no fields.

--- a/spec/predicates/null.md
+++ b/spec/predicates/null.md
@@ -6,7 +6,7 @@ Version: 1.0.0
 
 ## Purpose
 
-Denotes the absense of a predicate. May be used as a drop-in replacement for
+Denotes the absence of a predicate. May be used as a drop-in replacement for
 traditional code signing, where the notion of a predicate does not exist.
 
 ## Schema


### PR DESCRIPTION
This allows attestations to be used as a drop-in replacement for
existing code signing applications, where the predicate is not defined.

Fixes #9.