### PR TITLE
Switch Link to v0.1 (was v1).

### DIFF
--- a/spec/predicates/link.md
+++ b/spec/predicates/link.md
@@ -1,8 +1,8 @@
 # Predicate type: Link
 
-Type URI: https://in-toto.io/Link/v1
+Type URI: https://in-toto.io/Link/v0.1
 
-Version: 1.0.0
+Version: 0.1.0
 
 ## Purpose
 
@@ -22,7 +22,7 @@ Most users should migrate to a more specific attestation type, such as
   "subject": [{ ... }],
 
   // Predicate:
-  "predicateType": "https://in-toto.io/Link/v1",
+  "predicateType": "https://in-toto.io/Link/v0.1",
   "predicate": {
     "_type": "link",
     "name": "...",


### PR DESCRIPTION
It is not yet clear that the Link schema is finalized. Open questions:
- Should "_type" be optional?
- Should "products" be removed in favor of "subject"?

Since we are not yet decided, the 0.1 version makes this more clear.

NOTE: This goes against semantic versioning, but no one has depended on
this yet, and we do want to use the 0.x series to indicate "in
development", so it seems like a decent enough tradeoff to make at this
point.