### PR TITLE
lint: Use consistent emphasis style

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -66,17 +66,17 @@ The Envelope is the outermost layer of the attestation, handling authentication
 and serialization. The format and protocol are defined in [DSSE] and adopted by
 in-toto in [ITE-5]. It is a [JSON] object with the following fields:
 
-`payloadType` *string, required*
+`payloadType` _string, required_
 
 > Identifier for the encoding of the payload. Always
 > `application/vnd.in-toto+json`, which indicates that it is a JSON object with
 > a `_type` field indicating its schema.
 
-`payload` *string, required*
+`payload` _string, required_
 
 > Base64-encoded JSON [Statement].
 
-`signatures` *array of objects, required*
+`signatures` _array of objects, required_
 
 > One or more signatures over `payloadType` and `payload`, as defined in [DSSE].
 


### PR DESCRIPTION
Fixes markdownlint MD049 check (#83).