### PR TITLE
Support attestation subject URI as alternative for digest

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -148,8 +148,8 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 > Identifies an artifact by an immutable resource URI.
 > The `uri` field MUST be specified only if a subject cannot have a `digest` field.
 > 
-> Examples of subjects that cannot be identified by a digest, but that can be
-> identiified by an URI are a source-code revision (URI = svn+ssh://host/path/revision-number)
+> Examples of subjects that cannot be identified by a `digest`, but that can be
+> identiified by an `uri` are a source-code revision (URI = svn+ssh://host/path/revision-number)
 > or a builder API (URI = https://host/builder@version). 
 >
 > The semantics of an `uri` value MUST be _immutable_; for example each source-code

--- a/spec/README.md
+++ b/spec/README.md
@@ -148,8 +148,9 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 > Identifies an artifact by an immutable resource URI.
 > The `uri` field MUST be specified only if a subject cannot have a `digest` field.
 > 
-> Examples of a subject `uri` are a source-code revision (svn+ssh://host/path/revision-number)
-> or a builder API (https://host/builder@version). 
+> Examples of subjects that cannot be identified by a digest, but that can be
+> identiified by an URI are a source-code revision (URI = svn+ssh://host/path/revision-number)
+> or a builder API (URI = https://host/builder@version). 
 >
 > The semantics of an `uri` value MUST be _immutable_; for example each source-code
 > commit has a distinct revision number, and each semantic builder change has a

--- a/spec/README.md
+++ b/spec/README.md
@@ -122,8 +122,8 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 `subject[*].digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of this artifact.
-> This is the preferred form: only if a subject cannot have a `digest field,
-> the `uri` field MUST be specified.
+> This is the preferred form: the `uri` field MUST be specified only if a
+> subject cannot have a `digest field.
 >
 > Two DigestSets are considered matching if ANY of the fields match. The
 > producer and consumer must agree on acceptable algorithms. If there are no
@@ -146,7 +146,7 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 `subject[*].uri` _string ([ResourceURI]), optional_
 
 > Identifies an artifact by an immutable resource URI.
-> Use this form only if a subject cannot have a `digest` field.
+> The `uri` field MUST be specified only if a subject cannot have a `digest` field.
 >
 > The `uri` field SHOULD be specified for subjects that are not identified by 
 > a digest, such as a source-code revision (svn+ssh://host/path/revision-number)

--- a/spec/README.md
+++ b/spec/README.md
@@ -147,9 +147,8 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 
 > Identifies an artifact by an immutable resource URI.
 > The `uri` field MUST be specified only if a subject cannot have a `digest` field.
->
-> The `uri` field SHOULD be specified for subjects that are not identified by 
-> a digest, such as a source-code revision (svn+ssh://host/path/revision-number)
+> 
+> Examples of a subject `uri` are a source-code revision (svn+ssh://host/path/revision-number)
 > or a builder API (https://host/builder@version). 
 >
 > The semantics of an `uri` value MUST be _immutable_; for example each source-code

--- a/spec/README.md
+++ b/spec/README.md
@@ -270,7 +270,7 @@ Output (to be fed into policy engine):
 [JSON]: https://www.json.org
 [Link]: predicates/link.md
 [Predicate]: #predicate
-[ResourceURI]: field_types.md#TResourceURI
+[ResourceURI]: field_types.md#ResourceURI
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
 [SLSA Attestation Model]: https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md

--- a/spec/README.md
+++ b/spec/README.md
@@ -123,7 +123,7 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 
 > Collection of cryptographic digests for the contents of this artifact.
 > This is the preferred form: the `uri` field MUST be specified only if a
-> subject cannot have a `digest field.
+> subject cannot have a `digest` field.
 >
 > Two DigestSets are considered matching if ANY of the fields match. The
 > producer and consumer must agree on acceptable algorithms. If there are no

--- a/spec/README.md
+++ b/spec/README.md
@@ -122,7 +122,8 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 `subject[*].digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of this artifact.
-> A `subject` MUST have either a `digest` field or an `uri` field.
+> This is the preferred form: only if a subject cannot have a `digest field,
+> the `uri` field MUST be specified.
 >
 > Two DigestSets are considered matching if ANY of the fields match. The
 > producer and consumer must agree on acceptable algorithms. If there are no
@@ -145,7 +146,7 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 `subject[*].uri` _string ([ResourceURI]), optional_
 
 > Identifies an artifact by an immutable resource URI.
-> A `subject` MUST have either a `digest` field or an `uri` field.
+> Use this form only if a subject cannot have a `digest` field.
 >
 > The `uri` field SHOULD be specified for subjects that are not identified by 
 > a digest, such as a source-code revision (svn+ssh://host/path/revision-number)

--- a/spec/README.md
+++ b/spec/README.md
@@ -119,9 +119,10 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 > content type. If this matters to you, please comment on
 > [GitHub Issue #28](https://github.com/in-toto/attestation/issues/28)
 
-`subject[*].digest` _object ([DigestSet]), required_
+`subject[*].digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of this artifact.
+> A `subject` MUST have either a `digest` field or an `uri` field.
 >
 > Two DigestSets are considered matching if ANY of the fields match. The
 > producer and consumer must agree on acceptable algorithms. If there are no
@@ -140,6 +141,19 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 > apply regardless of what the artifact is named.
 >
 > MUST be non-empty and unique within `subject`.
+
+`subject[*].uri` _string ([ResourceURI]), optional_
+
+> Identifies an artifact by an immutable resource URI.
+> A `subject` MUST have either a `digest` field or an `uri` field.
+>
+> The `uri` field SHOULD be specified for subjects that are not identified by 
+> a digest, such as a source-code revision (svn+ssh://host/path/revision-number)
+> or a builder API (https://host/builder@version). 
+>
+> The semantics of an `uri` value MUST be _immutable_; for example each source-code
+> commit has a distinct revision number, and each semantic builder change has a
+> distinct API version.
 
 `predicateType` _string ([TypeURI]), required_
 
@@ -256,6 +270,7 @@ Output (to be fed into policy engine):
 [JSON]: https://www.json.org
 [Link]: predicates/link.md
 [Predicate]: #predicate
+[ResourceURI]: field_types.md#TResourceURI
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
 [SLSA Attestation Model]: https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md

--- a/spec/README.md
+++ b/spec/README.md
@@ -149,7 +149,7 @@ subject and unambiguously identifying the types of the [predicate]. It is a
 > The `uri` field MUST be specified only if a subject cannot have a `digest` field.
 > 
 > Examples of subjects that cannot be identified by a `digest`, but that can be
-> identiified by an `uri` are a source-code revision (URI = svn+ssh://host/path/revision-number)
+> identified by an `uri` are a source-code revision (URI = svn+ssh://host/path/revision-number)
 > or a builder API (URI = https://host/builder@version). 
 >
 > The semantics of an `uri` value MUST be _immutable_; for example each source-code


### PR DESCRIPTION
Hello, I am a member of the Google team, working with Mark Lodato, Tom Hennen and others.

Currently, an in-toto Attestation Statement subject has the form `{name, digest}` where both fields must be present. It is currently impossible to specify a subject that has no meaningful digest.

We would like to support subjects of the form `{name, uri}` for subjects that have no meaningful digest. Examples:

*    A subject URI that identifies a builder (example: https://host/builder@version). This could be the subject of an attestation that the builder meets a certain SLSA level, and it could be referenced in the builder section of a provenance attestation.
*    A subject URI that identifies a specific revision of a source-code repository (for example, svn+ssh://host/path/revision-number). This subject could be referenced in the materials section of a provenance attestation, and it could match the subject of an attestation that the repository meets a certain SLSA level.

More background is in #92.