### PR TITLE
Link to attestation model description on slsa.dev

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -258,7 +258,7 @@ Output (to be fed into policy engine):
 [Predicate]: #predicate
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
-[SLSA Attestation Model]: https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md
+[SLSA Attestation Model]: https://slsa.dev/attestation-model
 [SLSA Provenance]: https://slsa.dev/provenance
 [SPDX]: predicates/spdx.md
 [Statement]: #statement


### PR DESCRIPTION
The location for the linked content within the slsa-framework/slsa repository
has moved to a new place which is now rendered as part of slsa.dev, therefore
update the link to point to the rendered page https://slsa.dev/attestation-model