### PR TITLE
Add `goModuleH1` to the list of predefined digests

### DIFF
--- a/spec/field_types.md
+++ b/spec/field_types.md
@@ -11,10 +11,27 @@ _DigestSet (object)_
 > It is RECOMMENDED to use at least `sha256` for compatibility between producers
 > and consumers.
 >
-> Pre-defined algorithm names: `sha256`, `sha224`, `sha384`, `sha512`,
-> `sha512_224`, `sha512_256`, `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`,
-> `shake128`, `shake256`, `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`,
-> `sha1`, `md5`.
+> Pre-defined algorithms:
+>
+> -   `sha256`, `sha224`, `sha384`, `sha512`, `sha512_224`, `sha512_256`,
+>     `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, `shake128`, `shake256`,
+>     `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`, `sha1`, `md5`
+>
+>     Standard cryptographic hash algorithms, for cases when when the method of
+>     serialization is obvious or well known.
+>
+> -   `goModuleH1`: The go module [directory Hash1], omitting the "h1:"
+>     prefix and output in hexadecimal instead of base64. Can be computed over a
+>     directory named `name@version`, or the contents of zip file containing
+>     such a directory:
+>
+>     ```bash
+>     find name@version -type f | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut -f1 -d' '
+>     ```
+>
+>     For example, the module dirhash
+>     `h1:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=` would be encoded as
+>     `{"goModuleH1": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`.
 >
 > Consumers MUST only accept algorithms that they consider secure and MUST
 > ignore unrecognized or unaccepted algorithms. For example, most applications
@@ -27,6 +44,8 @@ _DigestSet (object)_
 > -   `{"sha256": "abcd", "sha512": "1234"}` matches `{"sha256": "abcd"}`
 > -   `{"sha256": "abcd"}` does not match `{"sha256": "fedb", "sha512": "abcd"}`
 > -   `{"somecoolhash": "abcd"}` uses a non-predefined algorithm
+
+[directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go
 
 <a id="ResourceURI"></a>
 _ResourceURI (string)_


### PR DESCRIPTION
This is the first digest algorithm that is not a straight cryptographic hash over a blob of data.

Decisions:
- Use the name `goModuleH1` instead of `goDirhash` or similar because (a) it makes it more clear that this is only for go modules and (b) to allow future H2, H3, etc. to be expressed in the same DigestSet.
- Use hex encoding instead of base64, since that is what we use elsewhere.

See #28 for background.