### PR TITLE
Clarify policy engines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository defines the in-toto **attestation** format, which represents
 authenticated metadata about a set of software artifacts. Attestations are
-intended for consumption by automated policy engines, such as [in-toto] and
+intended for consumption by automated policy engines, such as [OPA] and
 [Binary Authorization].
 
 ## IMPORTANT
@@ -297,3 +297,4 @@ keying primarily by resource name, in addition to content hash.
 [in-toto 0.9]: https://github.com/in-toto/docs/blob/v0.9/in-toto-spec.md
 [in-toto]: https://in-toto.io
 [processing model]: spec/README.md#processing-model
+[opa]: https://www.openpolicyagent.org/


### PR DESCRIPTION
This commit suggests updating the introduction section in README.md and replaces `in-toto` with `OPA` as an example of a policy engine.

The motivation for this change is that, based on my (limited) understanding of in-toto, I would not classify it as a policy engine.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>