### PR TITLE
Update parsing rules for unrecognized fields

### DIFF
--- a/spec/v1.0-draft/README.md
+++ b/spec/v1.0-draft/README.md
@@ -16,9 +16,10 @@ Index:
 The following rules apply to [Statement] and [Predicates] that opt-in to this
 model.
 
--   **Unrecognized fields:** Consumers MUST ignore unrecognized fields. This
-    is to allow minor version upgrades and extension fields. Ignoring fields
-    is safe due to the monotonic principle.
+-   **Unrecognized fields:** Consumers MUST ignore unrecognized fields unless
+    otherwise noted in the predicate specification. This is to allow minor
+    version upgrades and extension fields. Ignoring fields is safe due to the
+    monotonic principle.
 
 -   **Versioning:** Each type has a [SemVer2](https://semver.org) version
     number and the [TypeURI] reflects the major version number. A message is


### PR DESCRIPTION
There are cases where unrecognised fields SHOULD reject unrecognised fields, rather than ignoring them. This is true for the externaleParameters field in SLSA provenance v1 and the summary of the parsing rules included in that specification were recently updated to clarify. https://github.com/slsa-framework/slsa/pull/628

This change updates the guidance here to match.

Fixes: #138