### PR TITLE
Specify lowercase-hex encoding for standard algorithms only.

### DIFF
--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -53,7 +53,7 @@ Supported algorithms:
 > Two DigestSets SHOULD be considered matching if ANY acceptable field
 > matches.
 >
-> New algorithms must document how the value is encoded. E.g. base64,
+> New algorithms MUST document how the value is encoded, e.g. URL-safe base64,
 > lowercase hex, etc...
 
 ## Examples

--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -26,7 +26,7 @@ agility.
 Supported algorithms:
 
 -   Standard cryptographic hash algorithms using [the NIST names][]
-    (converting to lowercase and replacing `-` replaced with `_`) as keys
+    (converting to lowercase and replacing `-` with `_`) as keys
     and lowercase hex-encoded values, for cases when the method of
     serialization is obvious or well known:
     `sha256`, `sha224`, `sha384`, `sha512`, `sha512_224`, `sha512_256`,

--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -25,14 +25,15 @@ agility.
 
 Supported algorithms:
 
--   Standard cryptographic hash algorithms with lowercase hex-encoded
-    values, for cases when the method of serialization is obvious or
-    well known:
+-   Standard cryptographic hash algorithms using [the NIST names][nist-hashes]
+    (converting to lowercase and replacing `-` replaced with `_`) as keys
+    and lowercase hex-encoded values, for cases when the method of
+    serialization is obvious or well known:
     `sha256`, `sha224`, `sha384`, `sha512`, `sha512_224`, `sha512_256`,
     `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, `shake128`, `shake256`,
     `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`, `sha1`, `md5`
 
--   `goModuleH1`: The go module [directory Hash1][], omitting the "h1:"
+-   `goModuleH1`: The go module [directory Hash1][Hash1], omitting the "h1:"
     prefix and output in lowercase hexadecimal instead of base64. Can
     be computed over a directory named `name@version`, or the contents
     of zip file containing such a directory:
@@ -64,4 +65,5 @@ Supported algorithms:
 -   `{"sha256": "abcd"}` does not match `{"sha256": "fedb", "sha512": "abcd"}`
 -   `{"somecoolhash": "abcd"}` uses a non-predefined algorithm
 
-[directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go
+[nist-hashes]: https://csrc.nist.gov/projects/hash-functions
+[Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go

--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -18,8 +18,10 @@ metadata object.
 ## Fields
 
 A DigestSet is represented as a _JSON object_ mapping algorithm name to
-a string value. Usually there is just a single key/value pair, but
-multiple entries MAY be used for algorithm agility.
+a string encoding of the digest using that algorithm. The named standard
+algorithms below use lowercase hex encoding. Usually there is just a
+single key/value pair, but multiple entries MAY be used for algorithm
+agility.
 
 Supported algorithms:
 

--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -25,7 +25,7 @@ agility.
 
 Supported algorithms:
 
--   Standard cryptographic hash algorithms using [the NIST names][nist-hashes]
+-   Standard cryptographic hash algorithms using [the NIST names][]
     (converting to lowercase and replacing `-` replaced with `_`) as keys
     and lowercase hex-encoded values, for cases when the method of
     serialization is obvious or well known:
@@ -33,7 +33,7 @@ Supported algorithms:
     `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, `shake128`, `shake256`,
     `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`, `sha1`, `md5`
 
--   `goModuleH1`: The go module [directory Hash1][Hash1], omitting the "h1:"
+-   `goModuleH1`: The go module [directory Hash1][], omitting the "h1:"
     prefix and output in lowercase hexadecimal instead of base64. Can
     be computed over a directory named `name@version`, or the contents
     of zip file containing such a directory:
@@ -65,5 +65,5 @@ Supported algorithms:
 -   `{"sha256": "abcd"}` does not match `{"sha256": "fedb", "sha512": "abcd"}`
 -   `{"somecoolhash": "abcd"}` uses a non-predefined algorithm
 
-[nist-hashes]: https://csrc.nist.gov/projects/hash-functions
-[Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go
+[the NIST names]: https://csrc.nist.gov/projects/hash-functions
+[directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go

--- a/spec/v1.0-draft/digest_set.md
+++ b/spec/v1.0-draft/digest_set.md
@@ -18,23 +18,22 @@ metadata object.
 ## Fields
 
 A DigestSet is represented as a _JSON object_ mapping algorithm name to
-lowercase hex-encoded value. Usually there is just a single key/value pair,
-but multiple entries MAY be used for algorithm agility.
-
-> **TODO**: Add language for supporting base64-encoded digest values (re: goModuleH1).
+a string value. Usually there is just a single key/value pair, but
+multiple entries MAY be used for algorithm agility.
 
 Supported algorithms:
 
--   Standard cryptographic hash algorithms, for cases when the method
-    of serialization is obvious or well known:
+-   Standard cryptographic hash algorithms with lowercase hex-encoded
+    values, for cases when the method of serialization is obvious or
+    well known:
     `sha256`, `sha224`, `sha384`, `sha512`, `sha512_224`, `sha512_256`,
     `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, `shake128`, `shake256`,
     `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`, `sha1`, `md5`
 
 -   `goModuleH1`: The go module [directory Hash1][], omitting the "h1:"
-    prefix and output in hexadecimal instead of base64. Can be computed
-    over a directory named `name@version`, or the contents of zip file
-    containing such a directory:
+    prefix and output in lowercase hexadecimal instead of base64. Can
+    be computed over a directory named `name@version`, or the contents
+    of zip file containing such a directory:
 
     ```bash
     find name@version -type f | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut -f1 -d' '
@@ -53,6 +52,9 @@ Supported algorithms:
 >
 > Two DigestSets SHOULD be considered matching if ANY acceptable field
 > matches.
+>
+> New algorithms must document how the value is encoded. E.g. base64,
+> lowercase hex, etc...
 
 ## Examples
 


### PR DESCRIPTION
There are cases where custom digests might be better expressed using different encodings.

refs #130