### PR TITLE
Relax subject name

### DIFF
--- a/spec/v1.0-draft/statement.md
+++ b/spec/v1.0-draft/statement.md
@@ -54,13 +54,15 @@ Additional [parsing rules] apply.
 
 > Identifier to distinguish this artifact from others within the `subject`.
 >
-> The semantics are up to the producer and consumer. Because consumers evaluate
-> the name against a policy, the name SHOULD be stable between attestations. If
-> the name is not meaningful leave the field unset or use "\_". For example, a
-> [SLSA Provenance] attestation might use the name to specify output filename,
-> expecting the consumer to only considers entries with a particular name.
-> Alternatively, a vulnerability scan attestation might leave name unset
-> because the results apply regardless of what the artifact is named.
+> The semantics are up to the producer and consumer and they MAY use it when
+> evaluating policy. If the name is not meaningful leave the field unset or
+> use "\_". For example, a [SLSA Provenance] attestation might use the name
+> to specify output filename, expecting the consumer to only consider
+> entries with a particular name. Alternatively, a vulnerability scan
+> attestation might leave name unset because the results apply regardless of
+> what the artifact is named.
+>
+> If set `name` SHOULD be unique within subject.
 
 `predicateType` _string ([TypeURI]), required_
 

--- a/spec/v1.0-draft/statement.md
+++ b/spec/v1.0-draft/statement.md
@@ -55,14 +55,14 @@ Additional [parsing rules] apply.
 > Identifier to distinguish this artifact from others within the `subject`.
 >
 > The semantics are up to the producer and consumer and they MAY use it when
-> evaluating policy. If the name is not meaningful leave the field unset or
+> evaluating policy. If the name is not meaningful, leave the field unset or
 > use "\_". For example, a [SLSA Provenance] attestation might use the name
 > to specify output filename, expecting the consumer to only consider
 > entries with a particular name. Alternatively, a vulnerability scan
 > attestation might leave name unset because the results apply regardless of
 > what the artifact is named.
 >
-> If set `name` SHOULD be unique within subject.
+> If set, `name` SHOULD be unique within subject.
 
 `predicateType` _string ([TypeURI]), required_
 

--- a/spec/v1.0-draft/statement.md
+++ b/spec/v1.0-draft/statement.md
@@ -50,19 +50,17 @@ Additional [parsing rules] apply.
 > producer and consumer must agree on acceptable algorithms. If there are no
 > overlapping algorithms, the subject is considered not matching.
 
-`subject[*].name` _string, required_
+`subject[*].name` _string, optional_
 
 > Identifier to distinguish this artifact from others within the `subject`.
 >
 > The semantics are up to the producer and consumer. Because consumers evaluate
 > the name against a policy, the name SHOULD be stable between attestations. If
-> the name is not meaningful, use "\_". For example, a [SLSA Provenance]
-> attestation might use the name to specify output filename, expecting the
-> consumer to only considers entries with a particular name. Alternatively, a
-> vulnerability scan attestation might use the name "\_" because the results
-> apply regardless of what the artifact is named.
->
-> MUST be non-empty and unique within `subject`.
+> the name is not meaningful leave the field unset or use "\_". For example, a
+> [SLSA Provenance] attestation might use the name to specify output filename,
+> expecting the consumer to only considers entries with a particular name.
+> Alternatively, a vulnerability scan attestation might leave name unset
+> because the results apply regardless of what the artifact is named.
 
 `predicateType` _string ([TypeURI]), required_
 


### PR DESCRIPTION
Don't make producers set subject.name if it doesn't mean anything.
This simplifies their workflow and reduces the size & cost of
producing statements when there are a lot of subjects.

Retain option to use '_' for backwards compatibility, could
probably remove that without any harm.

fixes #142