### PR TITLE
Remove .0 from the _type uri

### DIFF
--- a/spec/v1.0-draft/statement.md
+++ b/spec/v1.0-draft/statement.md
@@ -10,7 +10,7 @@ particular subject and unambiguously identifying the types of the
 
 ```jsonc
 {
-  "_type": "https://in-toto.io/Statement/v1.0",
+  "_type": "https://in-toto.io/Statement/v1",
   "subject": [
     {
       "name": "<NAME>",
@@ -31,7 +31,7 @@ Additional [parsing rules] apply.
 `_type` _string ([TypeURI]), required_
 
 > Identifier for the schema of the Statement. Always
-> `https://in-toto.io/Statement/v1.0` for this version of the spec.
+> `https://in-toto.io/Statement/v1` for this version of the spec.
 
 `subject` _array of objects, required_
 

--- a/spec/v1.0-draft/statement.proto
+++ b/spec/v1.0-draft/statement.proto
@@ -11,7 +11,7 @@ option go_package = "github.com/in-toto/attestation/go/spec/v1.0-draft";
 // https://github.com/in-toto/attestation/tree/main/spec/v1.0-draft
 // Validation of all fields is left to the users of this proto.
 message Statement {
-  // Expected to always be "https://in-toto.io/Statement/v1.0"
+  // Expected to always be "https://in-toto.io/Statement/v1"
   string type = 1 [json_name = "_type"];
 
   message Subject {


### PR DESCRIPTION
Any minor changes should be backwards compatible so there's no need to identify type in the statement and it could actually be harmful.

Leaving it as is in docs and such because the text could change with point releases.

refs #130