### PR TITLE
Fix spdx download location URL

### DIFF
--- a/spec/v0.1.0/field_types.md
+++ b/spec/v0.1.0/field_types.md
@@ -88,4 +88,4 @@ _Timestamp (string)_
 [Package URL]: https://github.com/package-url/purl-spec/
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
-[SPDX Download Location]: https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
+[SPDX Download Location]: https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field

--- a/spec/v1.0-draft/field_types.md
+++ b/spec/v1.0-draft/field_types.md
@@ -66,6 +66,6 @@ in the UTC timezone ("Z").
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
 [ResourceURI]: scalar_field_types.md#ResourceURI
-[SPDX Download Location]: https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
+[SPDX Download Location]: https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field
 [Timestamp]: scalar_field_types.md#Timestamp
 [TypeURI]: scalar_field_types.md#TypeURI

--- a/spec/v1.0-draft/scalar_field_types.md
+++ b/spec/v1.0-draft/scalar_field_types.md
@@ -52,4 +52,4 @@ A point in time.
 [Package URL]: https://github.com/package-url/purl-spec/
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [RFC 3986]: https://tools.ietf.org/html/rfc3986
-[SPDX Download Location]: https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
+[SPDX Download Location]: https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field


### PR DESCRIPTION
The old link stopped working, it seems like we should link to a specific version.