### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# For a detailed list of maintainers, see MAINTAINERS.md.
+
+* @in-toto/attestation-maintainers


### PR DESCRIPTION
Not sure about this one. The governance model says codeowners file but IMO we should have a maintainers.md file to contain information beyond github usernames. This one may still be useful for automating review requests and so on. Thoughts?