### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ and establish trust in its supply chain, using in-toto attestations.
 
 ## Learning about in-toto attestations
 
-Visit [https://in-toto.io](https://in-toto.io) to learn about the larger
-in-toto project.
+To get started, check out the [overview] of the in-toto Attestation Framework.
 
 For a deeper dive, we recommend reading through our [documentation] to learn
 more about the goals of the in-toto Attestation Framework.
+
+Visit [https://in-toto.io](https://in-toto.io) to learn about the larger
+in-toto project.
 
 ## Working with in-toto attestations
 
@@ -58,6 +60,7 @@ the framework. In the meantime, please visit any of the language-specific
 [in-toto]: https://in-toto.io
 [in-toto implementations]: https://github.com/in-toto
 [issues]: https://github.com/in-toto/attestation/issues?q=is%3Aopen+is%3Aissue
+[overview]: spec/README.md#in-toto-attestation-framework-spec
 [protobuf definitions]: docs/protos.md
 [pull requests]: https://github.com/in-toto/attestation/pulls?q=is%3Aopen+is%3Apr
-[specification]: spec/
+[specification]: spec/v1.0/

--- a/spec/predicates/README.md
+++ b/spec/predicates/README.md
@@ -21,14 +21,18 @@ our [vetting process], and may be of general interest:
     operations.
 -   [SLSA Verification Summary]: SLSA verification decision about a software
     artifact.
+-   [SPDX]: SPDX-formatted BOM for software artifacts.
 -   [CycloneDX]: CycloneDX BOM for software artifacts.
+-   [Test Results]: A generic schema to express results of any type of tests.
 
+[CycloneDX]: https://cyclonedx.org/
 [Link]: link.md
 [New Predicate Guidelines]: ../../docs/new_predicate_guidelines.md
+[Runtime Traces]: runtime-trace.md
 [SCAI Report]: scai.md
 [SLSA Provenance]: https://slsa.dev/provenance
-[SLSA Verification Summary]: https://github.com/in-toto/attestation/blob/main/spec/predicates/vsa/vsa.md
+[SLSA Verification Summary]: vsa/vsa.md
+[SPDX]: spdx.md
+[Test Results]: test-results.md
 [in-toto 0.9]: https://github.com/in-toto/docs/blob/master/in-toto-spec.md#44-file-formats-namekeyid-prefixlink
 [vetting process]: ../../docs/new_predicate_guidelines.md#vetting-process
-[Runtime Traces]: runtime-trace.md
-[CycloneDX]: https://cyclonedx.org/

--- a/spec/v1.0/README.md
+++ b/spec/v1.0/README.md
@@ -18,8 +18,8 @@ types] for any layer of an in-toto attestation.
 
 ## Parsing rules
 
-The following rules apply to [Statement] and [Predicates] that opt-in to this
-model.
+The following rules apply to [Statement] and any [Predicate] that opt into
+this model.
 
 -   **Unrecognized fields:** Consumers MUST ignore unrecognized fields unless
     otherwise noted in the predicate specification. This is to allow minor

--- a/spec/v1.0/statement.md
+++ b/spec/v1.0/statement.md
@@ -75,6 +75,7 @@ Additional [parsing rules] apply.
 > predicate.
 
 [DigestSet]: digest_set.md
+[JSON]: https://www.json.org/json-en.html
 [Predicate]: predicate.md
 [SLSA Provenance]: https://slsa.dev/provenance
 [TypeURI]: field_types.md#TypeURI


### PR DESCRIPTION
This PR does three things:
* Fix broken links in documentation
* Add some missing predicate types to docs
* Highlight spec overview in top-level README to make attestation format more easy to find