### PR TITLE
Link to existing predicates from predicate.md

### DIFF
--- a/spec/v1.0/predicate.md
+++ b/spec/v1.0/predicate.md
@@ -30,3 +30,4 @@ Additional [parsing rules] apply.
 [Statement]: statement.md
 [TypeURI]: field_types.md#TypeURI
 [parsing rules]: README.md#parsing-rules
+[existing predicate type]: ../predicates


### PR DESCRIPTION
spec/v1.0/predicate.md linked to 'existing predicate type' but didn't actually define the link