### PR TITLE
Allow uses of ResourceDescriptor to require fields

### DIFF
--- a/spec/v1.0/resource_descriptor.md
+++ b/spec/v1.0/resource_descriptor.md
@@ -25,8 +25,12 @@ or immutable).
 
 ## Fields
 
-Though all fields are optional, a ResourceDescriptor MUST specify one of
-`uri`, `digest` or `content` at a minimum.
+Though all fields are optional, a ResourceDescriptor MUST specify one of `uri`,
+`digest` or `content` at a minimum. Further, a context that uses the
+ResourceDescriptor can require one or more fields. For example, a predicate may
+require the `name` and `digest` fields. Note that those requirements cannot
+override the minimum requirement of one of `uri`, `digest`, or `content`
+specified here.
 
 `name` _string, optional_
 


### PR DESCRIPTION
Currently, the `ResourceDescriptor` only mandates one of `uri`, `digest`, or `content`. However, some predicates (links for example) and/or the subject field in the Statement should be able to mandate one or more fields separately.