### PR TITLE
Update the SLSA provenance predicate to v1

### DIFF
--- a/protos/README.md
+++ b/protos/README.md
@@ -13,9 +13,11 @@ considered stable before the v1.1 tagged release. Use at your own risk.
 In addition to the core in-toto attestation spec, the following attestation
 predicates have protobuf definitions:
 
+-   [in-toto Link]: Generic predicate that records a software supply chain    step.
+-   [SLSA Provenance]: Describes how an artifact or set of artifacts was
+    produced.
 -   [SLSA Verification Summary]: SLSA verification decision about a software
     artifact.
--   [in-toto Link]: Generic predicate that records a software supply chain step.
 -   [Test Result]: Expresses the result of a test run in the software supply
     chain.
 
@@ -43,6 +45,7 @@ following packages as needed:
 Please read our protos [documentation] for instructions on building and
 testing the supported language bindings.
 
+[SLSA Provenance]: in_toto_attestation/predicates/provenance/
 [SLSA Verification Summary]: in_toto_attestation/predicates/vsa/
 [in-toto Link]: in_toto_attestation/predicates/link/
 [Test Result]: in_toto_attestation/predicates/test_result/

--- a/protos/in_toto_attestation/predicates/provenance/v1/provenance.proto
+++ b/protos/in_toto_attestation/predicates/provenance/v1/provenance.proto
@@ -1,0 +1,43 @@
+// Keep in sync with schema at https://github.com/slsa-framework/slsa/blob/main/docs/provenance/schema/v1/provenance.proto
+syntax = "proto3";
+
+package in_toto_attestation.predicates.provenance.v1;
+
+import "in_toto_attestation/v1/resource_descriptor.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/in-toto/attestation/go/predicates/provenance/v1";
+option java_package = "io.github.intoto.attestation.predicates.provenance.v1";
+
+// Proto representation of predicate type https://slsa.dev/provenance/v1
+// Validation of all fields is left to the users of this proto.
+message Provenance {
+  BuildDefinition build_definition = 1;
+  RunDetails run_details = 2;
+}
+
+message BuildDefinition {
+  string build_type = 1;
+  google.protobuf.Struct external_parameters = 2;
+  google.protobuf.Struct internal_parameters = 3;
+  repeated in_toto_attestation.v1.ResourceDescriptor resolved_dependencies = 4;
+}
+
+message RunDetails {
+  Builder builder = 1;
+  BuildMetadata metadata = 2;
+  repeated in_toto_attestation.v1.ResourceDescriptor byproducts = 3;
+}
+
+message Builder {
+  string id = 1;
+  map<string, string> version = 2;
+  repeated in_toto_attestation.v1.ResourceDescriptor builder_dependencies = 3;
+}
+
+message BuildMetadata {
+  string invocation_id = 1;
+  google.protobuf.Timestamp started_on = 2;
+  google.protobuf.Timestamp finished_on = 3;
+}

--- a/spec/predicates/provenance.md
+++ b/spec/predicates/provenance.md
@@ -1,7 +1,28 @@
-# MOVED: SLSA Provenance
+# Predicate type: SLSA Provenance
 
-Deprecated Type URI: `https://in-toto.io/Provenance/v0.1`
+Type URI: https://slsa.dev/provenance
 
-This predicate has been renamed to [https://slsa.dev/provenance](https://slsa.dev/provenance) to reflect
+Version: 1.0
+
+## Specification
+
+Please visit the [SLSA Provenance spec] for information on purpose, schema,
+parsing rules, etc.
+
+## Changelog and Migrations
+
+### New in v1.0
+
+-   See the SLSA Provenance [v1 change history].
+
+### New in v0.2
+
+-   Deprecated Type URI: `https://in-toto.io/Provenance/v0.1`
+-   This predicate has been renamed to [https://slsa.dev/provenance](https://slsa.dev/provenance) to reflect
 that it was designed specifically for [SLSA](https://slsa.dev). Please update
 references accordingly.
+-   More info at [v0.2 change history]
+
+[SLSA Provenance spec]: https://slsa.dev/provenance/v1
+[v0.2 change history]: https://slsa.dev/provenance/v1#v02
+[v1 change history]: https://slsa.dev/provenance/v1#change-history


### PR DESCRIPTION
Also adds the protobuf definition for the v1 predicate (per https://github.com/slsa-framework/slsa/issues/855).

Fixes #200 