### PR TITLE
Change annotations fields in ResourceDecriptor from objects to values

### DIFF
--- a/protos/in_toto_attestation/v1/resource_descriptor.proto
+++ b/protos/in_toto_attestation/v1/resource_descriptor.proto
@@ -23,5 +23,5 @@ message ResourceDescriptor {
 
   string mediaType = 6;
 
-  map<string, google.protobuf.Struct> annotations = 7;
+  map<string, google.protobuf.Value> annotations = 7;
 }

--- a/spec/v1/resource_descriptor.md
+++ b/spec/v1/resource_descriptor.md
@@ -16,8 +16,8 @@ or immutable).
   "downloadLocation": "<RESOURCE URI>",
   "mediaType": "<MIME TYPE>",
   "annotations": {
-    "<FIELD_1>": { /* object */ },
-    "<FIELD_2>": { /* object */ },
+    "<FIELD_1>": /* value */,
+    "<FIELD_2>": /* value */,
     ...
   }
 }
@@ -85,15 +85,18 @@ specified here.
 > prefixing types with `x.`, `prs.`, or `vnd.` to avoid collisions with other
 > producers.
 
-`annotations` _map <string, object>, optional_
+`annotations` _map <string, value>, optional_
 
 > This field MAY be used to provide additional information or metadata about
 > the resource or artifact that may be useful to the consumer when evaluating
 > the attestation against a policy.
 >
+> For maximum flexibility annotations may be any mapping from a field name to
+> any JSON value (string, number, object, array, boolean or _null_).
+>
 > The producer and consumer SHOULD agree on the semantics, and acceptable
-> fields and objects in the `annotations` map. Producers SHOULD follow the
-> same formatting conventions used in [extension fields].
+> fields and values in the `annotations` map. Producers SHOULD follow the
+> same naming conventions for annotation fields as for [extension fields].
 
 ## Semantics
 

--- a/spec/v1/resource_descriptor.md
+++ b/spec/v1/resource_descriptor.md
@@ -134,7 +134,7 @@ Pointer to a git repo (with annotations):
 {
   "uri": "git+https://github.com/actions/runner",
   "digest": { "sha1": "d61b27b8395512..." },
-  "annotations": { "git-review": { "twoPartyReview": false } }
+  "annotations": { "twoPartyReview": false }
 }
 ```
 


### PR DESCRIPTION
This change expands support from objects to all JSON values. This allows maximum flexibility for producers and better matches the implicit reading of the spec many, including the SLSA project, had.

Fixes: #242