### PR TITLE
Use lower_camel_case consistently for fields in protobuf definitions

### DIFF
--- a/docs/protos.md
+++ b/docs/protos.md
@@ -49,9 +49,10 @@ the message type [update guidelines].
 
 ## Regenerating proto libraries
 
-[It's typical to keep generated Go code in the repository itself](https://go.dev/doc/articles/go_command#:~:text=and%20then%20check%20those%20generated%20source%20files%20into%20your%20repository)
+[It's typical](https://go.dev/doc/articles/go_command#:~:text=and%20then%20check%20those%20generated%20source%20files%20into%20your%20repository)
+to keep code generated from protobuf definitions in the repository itself,
 since it makes users' lives much easier. However, do NOT manually regenerate
-and check in the libraries, if your change modifies or adds protos,
+and check in the libraries if your change modifies or adds protos.
 
 To ensure libraries are generated using consistent tooling, we have
 [automated their generation](/.github/workflows/make-protos.yml).

--- a/docs/protos.md
+++ b/docs/protos.md
@@ -18,7 +18,14 @@ sudo apt install build-essential protobuf-compiler golang python3 python3-pip
 ## Protobuf programming practices
 
 You should follow standard [protobuf programming practices] when developing
-a protobuf definition. In addition, we establish the following practices.
+a protobuf definition.
+
+**NOTE**: This means that while [specification documents] [by convention use]
+lowerCamelCase for field names, the protobuf definitions use lower_snake_case
+for field names per the standard protobuf convention.
+
+We establish the following project specific practices, in addition to the
+standard protobuf programming practices:
 
 ### Package versioning
 
@@ -57,4 +64,6 @@ merged.
 [update guidelines]: https://protobuf.dev/programming-guides/proto3/#updating
 [protos/]: ../protos/
 [semver guidelines]: https://semver.org/#summary
+[by convention use]: ../docs/new_predicate_guidelines.md#predicate-conventions
+[specification documents]: ../spec/
 [supported language bindings]: ../protos/README.md#supported-language-bindings

--- a/protos/in_toto_attestation/predicates/vsa/v0/vsa.proto
+++ b/protos/in_toto_attestation/predicates/vsa/v0/vsa.proto
@@ -16,9 +16,9 @@ message VerificationSummary {
   }
   Verifier verifier = 1;
 
-  google.protobuf.Timestamp timeVerified = 2 [json_name = "time_verified"];
+  google.protobuf.Timestamp time_verified = 2 [json_name = "time_verified"];
 
-  string resourceUri = 3 [json_name = "resource_uri"];
+  string resource_uri = 3 [json_name = "resource_uri"];
 
   message Policy {
     string uri = 1;
@@ -30,9 +30,9 @@ message VerificationSummary {
     string uri = 1;
     map<string, string> digest = 2;
   }
-  repeated InputAttestation inputAttestations = 5 [json_name = "input_attestations"];
+  repeated InputAttestation input_attestations = 5 [json_name = "input_attestations"];
 
-  string verificationResult = 6 [json_name = "verification_result"];
-  string policyLevel = 7 [json_name = "policy_level"];
-  map<string, uint64> dependencyLevels = 8 [json_name = "dependency_levels"];
+  string verification_result = 6 [json_name = "verification_result"];
+  string policy_level = 7 [json_name = "policy_level"];
+  map<string, uint64> dependency_levels = 8 [json_name = "dependency_levels"];
 }

--- a/protos/in_toto_attestation/v1/resource_descriptor.proto
+++ b/protos/in_toto_attestation/v1/resource_descriptor.proto
@@ -19,9 +19,9 @@ message ResourceDescriptor {
 
   bytes content = 4;
 
-  string downloadLocation = 5;
+  string download_location = 5;
 
-  string mediaType = 6;
+  string media_type = 6;
 
   map<string, google.protobuf.Struct> annotations = 7;
 }

--- a/protos/in_toto_attestation/v1/statement.proto
+++ b/protos/in_toto_attestation/v1/statement.proto
@@ -18,7 +18,7 @@ message Statement {
 
   repeated in_toto_attestation.v1.ResourceDescriptor subject = 2;
 
-  string predicateType = 3;
+  string predicate_type = 3;
 
   google.protobuf.Struct predicate = 4;
 }


### PR DESCRIPTION
We [claim](https://github.com/in-toto/attestation/blob/461c6b92b7f79f4bca73e6c69b68bf6121052221/docs/protos.md) to adhere to the protobuf programming practices, and thus should also follow the [style guide](https://protobuf.dev/programming-guides/style/#message-field-names) there.

The style guide states that message field names should be lower_snake_case, not lowerCamelCase. Our protobuf definitions are somewhat inconsistent, this PR normalises to lower_snake_case for field names in protobuf definitions.

Fixes: #250 