### PR TITLE
fix(tests): fix go tests since #251

### DIFF
--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -19,13 +19,13 @@ const badRd = `{"downloadLocation":"https://example.com/test.zip","mediaType":"t
 
 func createTestResourceDescriptor() (*ResourceDescriptor, error) {
 	// Create a ResourceDescriptor
-	a1, err := structpb.NewStruct(map[string]interface{}{
+	a1, err := structpb.NewValue(map[string]interface{}{
 		"keyStr": "value1",
 		"keyNum": 13})
 	if err != nil {
 		return nil, err
 	}
-	a2, err := structpb.NewStruct(map[string]interface{}{
+	a2, err := structpb.NewValue(map[string]interface{}{
 		"keyObj": map[string]interface{}{
 			"subKey": "subVal"}})
 	if err != nil {
@@ -41,7 +41,7 @@ func createTestResourceDescriptor() (*ResourceDescriptor, error) {
 		Content:          []byte("bytescontent"),
 		DownloadLocation: "https://example.com/test.zip",
 		MediaType:        "theMediaType",
-		Annotations:      map[string]*structpb.Struct{"a1": a1, "a2": a2},
+		Annotations:      map[string]*structpb.Value{"a1": a1, "a2": a2},
 	}, nil
 }
 


### PR DESCRIPTION
The changes in #251 to update the type of the annotation value in a resource descriptor was not reflected in the tests, causing them to fail. Update the tests to use the new annotation value type.

---

I'm not sure why the the follow-on auto-PR to update the generated code #258 did not trigger the [run-go-tests](https://github.com/in-toto/attestation/actions/workflows/run-go-tests.yml) workflow?