### PR TITLE
add missing trigger for push main branch in go-test workflow

### DIFF
--- a/.github/workflows/run-go-tests.yml
+++ b/.github/workflows/run-go-tests.yml
@@ -1,7 +1,11 @@
 name: Run Go tests
 on:
   workflow_dispatch:
-
+  push:
+    branches:
+      - main
+    paths:
+       - 'go/**'
   # Want to trigger these tests whenever the attestation
   # libraries are regenerated, or new modules/tests are
   # added to the language bindings

--- a/.github/workflows/run-go-tests.yml
+++ b/.github/workflows/run-go-tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-       - 'go/**'
+      - 'go/**'
   # Want to trigger these tests whenever the attestation
   # libraries are regenerated, or new modules/tests are
   # added to the language bindings


### PR DESCRIPTION
Fixes the issues where an auto-PR to update the generated code https://github.com/in-toto/attestation/pull/258 does not trigger the [run-go-tests](https://github.com/in-toto/attestation/actions/workflows/run-go-tests.yml) workflow.