### PR TITLE
Add Go validator APIs for Provenance v1 predicate

### DIFF
--- a/go/predicates/provenance/v1/provenance.go
+++ b/go/predicates/provenance/v1/provenance.go
@@ -18,6 +18,25 @@ var (
 	ErrRunDetailsRequired      = errors.New("RunDetails required")
 )
 
+func (m *BuildMetadata) Validate() error {
+	// check valid timestamps
+	s := m.GetStartedOn()
+	if s != nil {
+		if err := s.CheckValid(); err != nil {
+			return err
+		}
+	}
+
+	f := m.GetFinishedOn()
+	if f != nil {
+		if err := f.CheckValid(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (b *Builder) Validate() error {
 	// the id field is required for SLSA Build L1
 	if b.GetId() == "" {
@@ -71,6 +90,14 @@ func (r *RunDetails) Validate() error {
 	// check the Builder
 	if err := builder.Validate(); err != nil {
 		return err
+	}
+
+	// check the Metadata, if present
+	metadata := r.GetMetadata()
+	if metadata != nil {
+		if err := metadata.Validate(); err != nil {
+			return fmt.Errorf("Invalid RunDetails.Metadata: %w", err)
+		}
 	}
 
 	// check that all byproducts are valid RDs

--- a/go/predicates/provenance/v1/provenance.go
+++ b/go/predicates/provenance/v1/provenance.go
@@ -1,0 +1,113 @@
+/*
+Validator APIs for SLSA Provenance v1 protos.
+*/
+package v1
+
+import (
+	"errors"
+	"fmt"
+)
+
+// all of the following errors apply to SLSA Build L1 and above
+var (
+	ErrBuilderRequired         = errors.New("RunDetails.Builder required")
+	ErrBuilderIdRequired       = errors.New("Builder.Id required")
+	ErrBuildDefinitionRequired = errors.New("BuildeDefinition required")
+	ErrBuildTypeRequired       = errors.New("BuildDefinition.BuildType required")
+	ErrExternalParamsRequired  = errors.New("BuildDefinition.ExternalParameters required")
+	ErrRunDetailsRequired      = errors.New("RunDetails required")
+)
+
+func (b *Builder) Validate() error {
+	// the id field is required for SLSA Build L1
+	if b.GetId() == "" {
+		return ErrBuilderIdRequired
+	}
+
+	// check that all builderDependencies are valid RDs
+	builderDeps := b.GetBuilderDependencies()
+	if len(builderDeps) > 0 {
+		for i, rd := range builderDeps {
+			if err := rd.Validate(); err != nil {
+				return fmt.Errorf("Invalid Builder.BuilderDependencies[%d]: %w", i, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *BuildDefinition) Validate() error {
+	// the buildType field is required for SLSA Build L1
+	if b.GetBuildType() == "" {
+		return ErrBuildTypeRequired
+	}
+
+	// the externalParameters field is required for SLSA Build L1
+	if b.GetExternalParameters() == nil {
+		return ErrExternalParamsRequired
+	}
+
+	// check that all resolvedDependencies are valid RDs
+	resolvedDeps := b.GetResolvedDependencies()
+	if len(resolvedDeps) > 0 {
+		for i, rd := range resolvedDeps {
+			if err := rd.Validate(); err != nil {
+				return fmt.Errorf("Invalid BuildDefinition.ResolvedDependencies[%d]: %w", i, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *RunDetails) Validate() error {
+	// the builder field is required for SLSA Build L1
+	builder := r.GetBuilder()
+	if builder == nil {
+		return ErrBuilderRequired
+	}
+
+	// check the Builder
+	if err := builder.Validate(); err != nil {
+		return err
+	}
+
+	// check that all byproducts are valid RDs
+	byproducts := r.GetByproducts()
+	if len(byproducts) > 0 {
+		for i, rd := range byproducts {
+			if err := rd.Validate(); err != nil {
+				return fmt.Errorf("Invalid RunDetails.Byproducts[%d]: %w", i, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Provenance) Validate() error {
+	// the buildDefinition field is required for SLSA Build L1
+	buildDef := p.GetBuildDefinition()
+	if buildDef == nil {
+		return ErrBuildDefinitionRequired
+	}
+
+	// check the BuildDefinition
+	if err := buildDef.Validate(); err != nil {
+		return err
+	}
+
+	// the runDetails field is required for SLSA Build L1
+	runDetails := p.GetRunDetails()
+	if runDetails == nil {
+		return ErrRunDetailsRequired
+	}
+
+	// check the RunDetails
+	if err := runDetails.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/predicates/provenance/v1/provenance.go
+++ b/go/predicates/provenance/v1/provenance.go
@@ -6,16 +6,19 @@ package v1
 import (
 	"errors"
 	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // all of the following errors apply to SLSA Build L1 and above
 var (
-	ErrBuilderRequired         = errors.New("RunDetails.Builder required")
-	ErrBuilderIdRequired       = errors.New("Builder.Id required")
-	ErrBuildDefinitionRequired = errors.New("BuildeDefinition required")
-	ErrBuildTypeRequired       = errors.New("BuildDefinition.BuildType required")
-	ErrExternalParamsRequired  = errors.New("BuildDefinition.ExternalParameters required")
-	ErrRunDetailsRequired      = errors.New("RunDetails required")
+	ErrBuilderRequired         = errors.New("runDetails.builder required")
+	ErrBuilderIdRequired       = errors.New("runDetails.builder.id required")
+	ErrBuildDefinitionRequired = errors.New("buildDefinition required")
+	ErrBuildTypeRequired       = errors.New("buildDefinition.buildType required")
+	ErrExternalParamsRequired  = errors.New("buildDefinition.externalParameters required")
+	ErrRunDetailsRequired      = errors.New("runDetails required")
 )
 
 func (m *BuildMetadata) Validate() error {
@@ -63,7 +66,8 @@ func (b *BuildDefinition) Validate() error {
 	}
 
 	// the externalParameters field is required for SLSA Build L1
-	if b.GetExternalParameters() == nil {
+	ext := b.GetExternalParameters()
+	if ext == nil || proto.Equal(ext, &structpb.Struct{}) {
 		return ErrExternalParamsRequired
 	}
 
@@ -83,7 +87,7 @@ func (b *BuildDefinition) Validate() error {
 func (r *RunDetails) Validate() error {
 	// the builder field is required for SLSA Build L1
 	builder := r.GetBuilder()
-	if builder == nil {
+	if builder == nil || proto.Equal(builder, &Builder{}) {
 		return ErrBuilderRequired
 	}
 
@@ -94,7 +98,7 @@ func (r *RunDetails) Validate() error {
 
 	// check the Metadata, if present
 	metadata := r.GetMetadata()
-	if metadata != nil {
+	if metadata != nil && !proto.Equal(metadata, &BuildMetadata{}) {
 		if err := metadata.Validate(); err != nil {
 			return fmt.Errorf("Invalid RunDetails.Metadata: %w", err)
 		}
@@ -116,7 +120,7 @@ func (r *RunDetails) Validate() error {
 func (p *Provenance) Validate() error {
 	// the buildDefinition field is required for SLSA Build L1
 	buildDef := p.GetBuildDefinition()
-	if buildDef == nil {
+	if buildDef == nil || proto.Equal(buildDef, &BuildDefinition{}) {
 		return ErrBuildDefinitionRequired
 	}
 
@@ -127,7 +131,7 @@ func (p *Provenance) Validate() error {
 
 	// the runDetails field is required for SLSA Build L1
 	runDetails := p.GetRunDetails()
-	if runDetails == nil {
+	if runDetails == nil || proto.Equal(runDetails, &RunDetails{}) {
 		return ErrRunDetailsRequired
 	}
 

--- a/go/predicates/provenance/v1/provenance.go
+++ b/go/predicates/provenance/v1/provenance.go
@@ -26,14 +26,14 @@ func (m *BuildMetadata) Validate() error {
 	s := m.GetStartedOn()
 	if s != nil {
 		if err := s.CheckValid(); err != nil {
-			return err
+			return fmt.Errorf("buildMetadata.startedOn error: %w", err)
 		}
 	}
 
 	f := m.GetFinishedOn()
 	if f != nil {
 		if err := f.CheckValid(); err != nil {
-			return err
+			return fmt.Errorf("buildMetadata.finishedOn error: %w", err)
 		}
 	}
 
@@ -48,11 +48,9 @@ func (b *Builder) Validate() error {
 
 	// check that all builderDependencies are valid RDs
 	builderDeps := b.GetBuilderDependencies()
-	if len(builderDeps) > 0 {
-		for i, rd := range builderDeps {
-			if err := rd.Validate(); err != nil {
-				return fmt.Errorf("Invalid Builder.BuilderDependencies[%d]: %w", i, err)
-			}
+	for i, rd := range builderDeps {
+		if err := rd.Validate(); err != nil {
+			return fmt.Errorf("Invalid Builder.BuilderDependencies[%d]: %w", i, err)
 		}
 	}
 
@@ -73,11 +71,9 @@ func (b *BuildDefinition) Validate() error {
 
 	// check that all resolvedDependencies are valid RDs
 	resolvedDeps := b.GetResolvedDependencies()
-	if len(resolvedDeps) > 0 {
-		for i, rd := range resolvedDeps {
-			if err := rd.Validate(); err != nil {
-				return fmt.Errorf("Invalid BuildDefinition.ResolvedDependencies[%d]: %w", i, err)
-			}
+	for i, rd := range resolvedDeps {
+		if err := rd.Validate(); err != nil {
+			return fmt.Errorf("Invalid BuildDefinition.ResolvedDependencies[%d]: %w", i, err)
 		}
 	}
 
@@ -93,7 +89,7 @@ func (r *RunDetails) Validate() error {
 
 	// check the Builder
 	if err := builder.Validate(); err != nil {
-		return err
+		return fmt.Errorf("runDetails.builder error: %w", err)
 	}
 
 	// check the Metadata, if present
@@ -106,11 +102,9 @@ func (r *RunDetails) Validate() error {
 
 	// check that all byproducts are valid RDs
 	byproducts := r.GetByproducts()
-	if len(byproducts) > 0 {
-		for i, rd := range byproducts {
-			if err := rd.Validate(); err != nil {
-				return fmt.Errorf("Invalid RunDetails.Byproducts[%d]: %w", i, err)
-			}
+	for i, rd := range byproducts {
+		if err := rd.Validate(); err != nil {
+			return fmt.Errorf("Invalid RunDetails.Byproducts[%d]: %w", i, err)
 		}
 	}
 
@@ -126,7 +120,7 @@ func (p *Provenance) Validate() error {
 
 	// check the BuildDefinition
 	if err := buildDef.Validate(); err != nil {
-		return err
+		return fmt.Errorf("provenance.buildDefinition error: %w", err)
 	}
 
 	// the runDetails field is required for SLSA Build L1
@@ -137,7 +131,7 @@ func (p *Provenance) Validate() error {
 
 	// check the RunDetails
 	if err := runDetails.Validate(); err != nil {
-		return err
+		return fmt.Errorf("provenance.runDetails error: %w", err)
 	}
 
 	return nil

--- a/go/predicates/provenance/v1/provenance_test.go
+++ b/go/predicates/provenance/v1/provenance_test.go
@@ -5,6 +5,7 @@ Tests for SLSA Provenance v1 protos.
 package v1
 
 import (
+	"fmt"
 	"testing"
 
 	ita1 "github.com/in-toto/attestation/go/v1"
@@ -69,4 +70,70 @@ func TestJsonUnmarshalProvenance(t *testing.T) {
 	want := createTestProvenance(t)
 	assert.NoError(t, err, "unexpected error during test Statement creation")
 	assert.True(t, proto.Equal(got, want), "protos do not match")
+}
+
+func TestBadProvenanceBuildDefinition(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		err          error
+		noErrMessage string
+	}{
+		"no buildDefinition": {
+			input:        `{"buildDefinition":{},"runDetails":{"builder":{"id":"theId","version":{"theComponent":"v0.1"},"builderDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`,
+			err:          ErrBuildDefinitionRequired,
+			noErrMessage: "created malformed Provenance (empty buildDefinition)",
+		},
+		"buildDefinition missing buildType required field": {
+			input:        `{"buildDefinition":{"externalParameters":{"param1":{"subKey":"subVal"}},"resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{"builder":{"id":"theId","version":{"theComponent":"v0.1"},"builderDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`,
+			err:          ErrBuildTypeRequired,
+			noErrMessage: "created malformed Provenance (buildDefinition missing required buildType field)",
+		},
+		"buildDefinition missing externalParameters required field": {
+			input:        `{"buildDefinition":{"buildType":"theBuildType","resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{"builder":{"id":"theId","version":{"theComponent":"v0.1"},"builderDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`,
+			err:          ErrExternalParamsRequired,
+			noErrMessage: "created malformed Provenance (buildDefinition missing requried externalParameters field)",
+		},
+	}
+
+	for name, test := range tests {
+		got := &Provenance{}
+		err := protojson.Unmarshal([]byte(test.input), got)
+		assert.NoError(t, err, fmt.Sprintf("error during JSON unmarshalling in test '%s'", name))
+
+		err = got.Validate()
+		assert.ErrorIs(t, err, test.err, fmt.Sprintf("%s in test '%s'", test.noErrMessage, name))
+	}
+}
+
+func TestBadProvenanceRunDetails(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		err          error
+		noErrMessage string
+	}{
+		"no runDetails": {
+			input:        `{"buildDefinition":{"buildType":"theBuildType","externalParameters":{"param1":{"subKey":"subVal"}},"resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{}}`,
+			err:          ErrRunDetailsRequired,
+			noErrMessage: "created malformed Provenance (empty runDetails)",
+		},
+		"runDetails missing builder required field": {
+			input:        `{"buildDefinition":{"buildType":"theBuildType","externalParameters":{"param1":{"subKey":"subVal"}},"resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{"builder":{},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`,
+			err:          ErrBuilderRequired,
+			noErrMessage: "created malformed Provenance (runDetails missing required builder field)",
+		},
+		"runDetails.builder missing id required field": {
+			input:        `{"buildDefinition":{"buildType":"theBuildType","externalParameters":{"param1":{"subKey":"subVal"}},"resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{"builder":{"id":"","version":{"theComponent":"v0.1"},"builderDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`,
+			err:          ErrBuilderIdRequired,
+			noErrMessage: "created malformed Provenance (runDetails.builder missing requried id field)",
+		},
+	}
+
+	for name, test := range tests {
+		got := &Provenance{}
+		err := protojson.Unmarshal([]byte(test.input), got)
+		assert.NoError(t, err, fmt.Sprintf("error during JSON unmarshalling in test '%s'", name))
+
+		err = got.Validate()
+		assert.ErrorIs(t, err, test.err, fmt.Sprintf("%s in test '%s'", test.noErrMessage, name))
+	}
 }

--- a/go/predicates/provenance/v1/provenance_test.go
+++ b/go/predicates/provenance/v1/provenance_test.go
@@ -1,0 +1,72 @@
+/*
+Tests for SLSA Provenance v1 protos.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	ita1 "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func createTestProvenance(t *testing.T) *Provenance {
+	// Create a Provenance
+
+	t.Helper()
+
+	rd := &ita1.ResourceDescriptor{
+		Name:   "theResource",
+		Digest: map[string]string{"alg1": "abc123"},
+	}
+
+	builder := &Builder{
+		Id:                  "theId",
+		Version:             map[string]string{"theComponent": "v0.1"},
+		BuilderDependencies: []*ita1.ResourceDescriptor{rd},
+	}
+
+	buildMeta := &BuildMetadata{
+		InvocationId: "theInvocationId",
+	}
+
+	runDetails := &RunDetails{
+		Builder:    builder,
+		Metadata:   buildMeta,
+		Byproducts: []*ita1.ResourceDescriptor{rd},
+	}
+
+	externalParams, err := structpb.NewStruct(map[string]interface{}{
+		"param1": map[string]interface{}{
+			"subKey": "subVal"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buildDef := &BuildDefinition{
+		BuildType:            "theBuildType",
+		ExternalParameters:   externalParams,
+		ResolvedDependencies: []*ita1.ResourceDescriptor{rd},
+	}
+
+	return &Provenance{
+		BuildDefinition: buildDef,
+		RunDetails:      runDetails,
+	}
+}
+
+func TestJsonUnmarshalProvenance(t *testing.T) {
+	var wantSt = `{"buildDefinition":{"buildType":"theBuildType","externalParameters":{"param1":{"subKey":"subVal"}},"resolvedDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"runDetails":{"builder":{"id":"theId","version":{"theComponent":"v0.1"},"builderDependencies":[{"name":"theResource","digest":{"alg1":"abc123"}}]},"metadata":{"invocationId":"theInvocationId"},"byproducts":[{"name":"theResource","digest":{"alg1":"abc123"}}]}}`
+
+	got := &Provenance{}
+	err := protojson.Unmarshal([]byte(wantSt), got)
+	assert.NoError(t, err, "error during JSON unmarshalling")
+
+	want := createTestProvenance(t)
+	assert.NoError(t, err, "unexpected error during test Statement creation")
+	assert.True(t, proto.Equal(got, want), "protos do not match")
+}


### PR DESCRIPTION
This PR adds Validate() functions for the SLSA Provenance v1 Go bindings, per the [SLSA Provenance v1 spec](https://slsa.dev/spec/v1.0/provenance#provenance), as well as basic tests. 

Note: This PR is a blocker for ITE-6/ITE-9 integration in in-toto-golang: https://github.com/in-toto/in-toto-golang/pull/268.