### PR TITLE
Add DigestSet hex encoding validation

### DIFF
--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -35,11 +35,12 @@ func (d *ResourceDescriptor) Validate() error {
 	if len(d.GetDigest()) > 0 {
 		for alg, digest := range d.GetDigest() {
 
-			// check encoding and length for supported algorithms
+			// Per https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
+			// check encoding and length for supported algorithms;
+			// use of custom, unsupported algorithms is allowed and does not not generate validation errors.
 			supported, size := isSupportedAlgorithm(alg)
 			if supported {
 				// the in-toto spec expects a hex-encoded string in DigestSets for supported algorithms
-				// https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
 				hashBytes, err := hex.DecodeString(digest)
 
 				if err != nil {

--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -5,14 +5,26 @@ Wrapper APIs for in-toto attestation ResourceDescriptor protos.
 package v1
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha512"
 	"encoding/hex"
 	"errors"
 )
 
 var (
+	ErrIncorrectDigestLength = errors.New("digest is not correct length")
 	ErrInvalidDigestEncoding = errors.New("digest is not valid hex-encoded string")
 	ErrRDRequiredField       = errors.New("at least one of name, URI, or digest are required")
 )
+
+// Supported standard hash algorithms
+func isSupportedAlgorithm(alg string) (bool, int) {
+	algos := map[string]int{"md5": md5.Size, "sha1": sha1.Size, "shake128": md5.Size, "sha224": sha512.Size224, "sha3_224": sha512.Size224, "sha512_224": sha512.Size224, "sha256": sha512.Size256, "sha3_256": sha512.Size256, "sha512_256": sha512.Size256, "shake256": sha512.Size256, "sha384": sha512.Size384, "sha3_384": sha512.Size384, "sha512_384": sha512.Size384, "sha512": sha512.Size, "sha3_512": sha512.Size, "dirHash": sha512.Size256, "gitCommit": sha1.Size}
+
+	size, ok := algos[alg]
+	return ok, size
+}
 
 func (d *ResourceDescriptor) Validate() error {
 	// at least one of name, URI or digest are required
@@ -20,14 +32,24 @@ func (d *ResourceDescriptor) Validate() error {
 		return ErrRDRequiredField
 	}
 
-	// the in-toto spec expects a hex-encoded string in DigestSets
-	// https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
 	if len(d.GetDigest()) > 0 {
-		for _, digest := range d.GetDigest() {
-			_, err := hex.DecodeString(digest)
+		for alg, digest := range d.GetDigest() {
 
-			if err != nil {
-				return ErrInvalidDigestEncoding
+			// check encoding and length for supported algorithms
+			supported, size := isSupportedAlgorithm(alg)
+			if supported {
+				// the in-toto spec expects a hex-encoded string in DigestSets for supported algorithms
+				// https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
+				hashBytes, err := hex.DecodeString(digest)
+
+				if err != nil {
+					return ErrInvalidDigestEncoding
+				}
+
+				// check the length of the digest
+				if len(hashBytes) != size {
+					return ErrIncorrectDigestLength
+				}
 			}
 		}
 	}

--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -5,22 +5,24 @@ Wrapper APIs for in-toto attestation ResourceDescriptor protos.
 package v1
 
 import (
-	"crypto/md5"
-	"crypto/sha1"
-	"crypto/sha512"
 	"encoding/hex"
 	"errors"
+	"fmt"
 )
 
 var (
-	ErrIncorrectDigestLength = errors.New("digest is not correct length")
+	ErrIncorrectDigestLength = errors.New("digest has incorrect length")
 	ErrInvalidDigestEncoding = errors.New("digest is not valid hex-encoded string")
 	ErrRDRequiredField       = errors.New("at least one of name, URI, or digest are required")
 )
 
-// Supported standard hash algorithms
-func isSupportedAlgorithm(alg string) (bool, int) {
-	algos := map[string]int{"md5": md5.Size, "sha1": sha1.Size, "shake128": md5.Size, "sha224": sha512.Size224, "sha3_224": sha512.Size224, "sha512_224": sha512.Size224, "sha256": sha512.Size256, "sha3_256": sha512.Size256, "sha512_256": sha512.Size256, "shake256": sha512.Size256, "sha384": sha512.Size384, "sha3_384": sha512.Size384, "sha512_384": sha512.Size384, "sha512": sha512.Size, "sha3_512": sha512.Size, "dirHash": sha512.Size256, "gitCommit": sha1.Size}
+// Indicates if a given fixed-size hash algorithm is supported by default and returns the algorithm's
+// digest size in bytes, if supported. We assume gitCommit and dirHash are aliases for sha1 and sha256, respectively.
+//
+// SHA digest sizes from https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
+// MD5 digest size from https://www.rfc-editor.org/rfc/rfc1321.html#section-1
+func isSupportedFixedSizeAlgorithm(alg string) (bool, int) {
+	algos := map[string]int{"md5": 16, "sha1": 20, "sha224": 28, "sha512_224": 28, "sha256": 32, "sha512_256": 32, "sha384": 48, "sha512": 64, "sha3_224": 28, "sha3_256": 32, "sha3_384": 48, "sha3_512": 64, "gitCommit": 20, "dirHash": 32}
 
 	size, ok := algos[alg]
 	return ok, size
@@ -38,18 +40,18 @@ func (d *ResourceDescriptor) Validate() error {
 			// Per https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
 			// check encoding and length for supported algorithms;
 			// use of custom, unsupported algorithms is allowed and does not not generate validation errors.
-			supported, size := isSupportedAlgorithm(alg)
+			supported, size := isSupportedFixedSizeAlgorithm(alg)
 			if supported {
 				// the in-toto spec expects a hex-encoded string in DigestSets for supported algorithms
 				hashBytes, err := hex.DecodeString(digest)
 
 				if err != nil {
-					return ErrInvalidDigestEncoding
+					return fmt.Errorf("%w: %s", ErrInvalidDigestEncoding, alg)
 				}
 
 				// check the length of the digest
 				if len(hashBytes) != size {
-					return ErrIncorrectDigestLength
+					return fmt.Errorf("%w: %s (got %d bytes, want %d bytes", ErrIncorrectDigestLength, alg, len(hashBytes), size)
 				}
 			}
 		}

--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -4,14 +4,32 @@ Wrapper APIs for in-toto attestation ResourceDescriptor protos.
 
 package v1
 
-import "errors"
+import (
+	"encoding/hex"
+	"errors"
+)
 
-var ErrRDRequiredField = errors.New("at least one of name, URI, or digest are required")
+var (
+	ErrInvalidDigestEncoding = errors.New("digest is not valid hex-encoded string")
+	ErrRDRequiredField       = errors.New("at least one of name, URI, or digest are required")
+)
 
 func (d *ResourceDescriptor) Validate() error {
 	// at least one of name, URI or digest are required
 	if d.GetName() == "" && d.GetUri() == "" && len(d.GetDigest()) == 0 {
 		return ErrRDRequiredField
+	}
+
+	// the in-toto spec expects a hex-encoded string in DigestSets
+	// https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
+	if len(d.GetDigest()) > 0 {
+		for _, digest := range d.GetDigest() {
+			_, err := hex.DecodeString(digest)
+
+			if err != nil {
+				return ErrInvalidDigestEncoding
+			}
+		}
 	}
 
 	return nil

--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -46,12 +46,12 @@ func (d *ResourceDescriptor) Validate() error {
 				hashBytes, err := hex.DecodeString(digest)
 
 				if err != nil {
-					return fmt.Errorf("%w: %s", ErrInvalidDigestEncoding, alg)
+					return fmt.Errorf("%w (%s: %s)", ErrInvalidDigestEncoding, alg, digest)
 				}
 
 				// check the length of the digest
 				if len(hashBytes) != size {
-					return fmt.Errorf("%w: %s (got %d bytes, want %d bytes", ErrIncorrectDigestLength, alg, len(hashBytes), size)
+					return fmt.Errorf("%w: got %d bytes, want %d bytes (%s: %s)", ErrIncorrectDigestLength, len(hashBytes), size, alg, digest)
 				}
 			}
 		}

--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -17,6 +17,8 @@ const wantFullRd = `{"name":"theName","uri":"https://example.com","digest":{"alg
 
 const badRd = `{"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
 
+const badRdDigest = `{"digest":{"alg1":"badDigest"},"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
+
 func createTestResourceDescriptor() (*ResourceDescriptor, error) {
 	// Create a ResourceDescriptor
 	a, err := structpb.NewStruct(map[string]interface{}{
@@ -64,4 +66,14 @@ func TestBadResourceDescriptor(t *testing.T) {
 
 	err = got.Validate()
 	assert.ErrorIs(t, err, ErrRDRequiredField, "created malformed ResourceDescriptor")
+}
+
+func TestBadResourceDescriptorDigest(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(badRdDigest), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.ErrorIs(t, err, ErrInvalidDigestEncoding, "created ResourceDescriptor with invalid digest encoding")
 }

--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -17,7 +17,9 @@ const wantFullRd = `{"name":"theName","uri":"https://example.com","digest":{"alg
 
 const badRd = `{"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
 
-const badRdDigest = `{"digest":{"alg1":"badDigest"},"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
+const badRdDigestEncoding = `{"digest":{"sha256":"badDigest"},"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
+
+const badRdDigestLength = `{"digest":{"sha256":"abc123"},"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
 
 func createTestResourceDescriptor() (*ResourceDescriptor, error) {
 	// Create a ResourceDescriptor
@@ -68,12 +70,22 @@ func TestBadResourceDescriptor(t *testing.T) {
 	assert.ErrorIs(t, err, ErrRDRequiredField, "created malformed ResourceDescriptor")
 }
 
-func TestBadResourceDescriptorDigest(t *testing.T) {
+func TestBadResourceDescriptorDigestEncoding(t *testing.T) {
 	got := &ResourceDescriptor{}
-	err := protojson.Unmarshal([]byte(badRdDigest), got)
+	err := protojson.Unmarshal([]byte(badRdDigestEncoding), got)
 
 	assert.NoError(t, err, "Error during JSON unmarshalling")
 
 	err = got.Validate()
 	assert.ErrorIs(t, err, ErrInvalidDigestEncoding, "created ResourceDescriptor with invalid digest encoding")
+}
+
+func TestBadResourceDescriptorDigestLength(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(badRdDigestLength), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.ErrorIs(t, err, ErrIncorrectDigestLength, "created ResourceDescriptor with incorrect digest length")
 }

--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -89,7 +89,7 @@ func TestBadResourceDescriptorDigestEncoding(t *testing.T) {
 	assert.NoError(t, err, "Error during JSON unmarshalling")
 
 	err = got.Validate()
-	assert.ErrorIs(t, err, ErrInvalidDigestEncoding, "created ResourceDescriptor with invalid digest encoding")
+	assert.ErrorIs(t, err, ErrInvalidDigestEncoding, "did not get expected error when validating ResourceDescriptor with invalid digest encoding")
 }
 
 func TestBadResourceDescriptorDigestLength(t *testing.T) {
@@ -99,5 +99,5 @@ func TestBadResourceDescriptorDigestLength(t *testing.T) {
 	assert.NoError(t, err, "Error during JSON unmarshalling")
 
 	err = got.Validate()
-	assert.ErrorIs(t, err, ErrIncorrectDigestLength, "created ResourceDescriptor with incorrect digest length")
+	assert.ErrorIs(t, err, ErrIncorrectDigestLength, "did not get expected error when validating ResourceDescriptor with incorrect digest length")
 }

--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -15,6 +15,8 @@ import (
 
 const wantFullRd = `{"name":"theName","uri":"https://example.com","digest":{"alg1":"abc123"},"content":"Ynl0ZXNjb250ZW50","downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType","annotations":{"a1":{"keyNum": 13,"keyStr":"value1"},"a2":{"keyObj":{"subKey":"subVal"}}}}`
 
+const supportedRdDigest = `{"digest":{"sha256":"a1234567b1234567c1234567d1234567e1234567f1234567a1234567b1234567","custom":"myCustomEnvoding","sha1":"a1234567b1234567c1234567d1234567e1234567"}}`
+
 const badRd = `{"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
 
 const badRdDigestEncoding = `{"digest":{"sha256":"badDigest"},"downloadLocation":"https://example.com/test.zip","mediaType":"theMediaType"}`
@@ -58,6 +60,16 @@ func TestJsonUnmarshalResourceDescriptor(t *testing.T) {
 
 	assert.NoError(t, err, "Error during test RD creation")
 	assert.True(t, proto.Equal(got, want), "Protos do not match")
+}
+
+func TestSupportedResourceDescriptorDigest(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(supportedRdDigest), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.NoError(t, err, "Error during validation of valid supported RD digests")
 }
 
 func TestBadResourceDescriptor(t *testing.T) {


### PR DESCRIPTION
Since the spec requires digests in a DigestSet to be hex-encoded, this PR enhances the `Validate()` function for the ResourceDescriptor and adds a corresponding test.