### PR TITLE
Only run python tests for changes to Python APIs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'python/**'
   pull_request:
+    paths:
+      - 'python/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The python CI tests currently run on every single PR and push to main, even if no changes to the Python APIs have been made. This PR limits python testing to changes under the `python/` directory.