### PR TITLE
Clarify that digests don't have to be cryptographic ones.

### DIFF
--- a/spec/v1/CHANGELOG.md
+++ b/spec/v1/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v1.1
+
+* Clarified that subjects are assumed to be immuatble and that it is
+acceptable to use a non-cryptographic digest (though cryptographic
+digests are still preferred).
+
+## v1
+
+Initial release.

--- a/spec/v1/CHANGELOG.md
+++ b/spec/v1/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1
 
-* Clarified that subjects are assumed to be immuatble and that it is
+-   Clarified that subjects are assumed to be immuatble and that it is
 acceptable to use a non-cryptographic digest (though cryptographic
 digests are still preferred).
 

--- a/spec/v1/CHANGELOG.md
+++ b/spec/v1/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v1.1
 
--   Clarified that subjects are assumed to be immuatble and that it is
+-   Clarified that subjects are assumed to be immutable and that it is
 acceptable to use a non-cryptographic digest (though cryptographic
-digests are still preferred).
+digests are still strongly recommended).
 
 ## v1
 

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -1,6 +1,6 @@
 # Specification for in-toto attestation layers
 
-Version: v1.0
+Version: v1.1
 
 Index:
 

--- a/spec/v1/bundle.md
+++ b/spec/v1/bundle.md
@@ -1,7 +1,5 @@
 # Bundle layer specification
 
-Version: v1.0
-
 An attestation Bundle is a collection of multiple attestations in a single
 file. This allows attestations from multiple different points in the software
 supply chain (e.g. Provenance, Code Review, Test Result, vuln scan, ...) to

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -23,7 +23,7 @@ algorithms below use lowercase hex encoding. Usually there is just a
 single key/value pair, but multiple entries MAY be used for algorithm
 agility.
 
-Users SHOULD use a _cryptographic_ digest, but MAY use another identifier 
+Users SHOULD use a _cryptographic_ digest, but MAY use another identifier
 if the underlying implementation ensures immutability via other means.
 
 ### Supported algorithms

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -2,8 +2,8 @@
 
 Version: v1.1
 
-Set of one or more immutable digests for a single software artifact or
-metadata object.
+Set of one or more immutable digests for a single software artifact or metadata
+object.
 
 ## Schema
 
@@ -11,20 +11,19 @@ metadata object.
 {
   "<ALGORITHM_1>": "<VALUE>",
   "<ALGORITHM_2>": "<VALUE>",
-  ... 
+  ...
 }
 ```
 
 ## Fields
 
-A DigestSet is represented as a _JSON object_ mapping algorithm name to
-a string encoding of the digest using that algorithm. The named standard
-algorithms below use lowercase hex encoding. Usually there is just a
-single key/value pair, but multiple entries MAY be used for algorithm
-agility.
+A DigestSet is represented as a *JSON object* mapping algorithm name to a string
+encoding of the digest using that algorithm. The named standard algorithms below
+use lowercase hex encoding. Usually there is just a single key/value pair, but
+multiple entries MAY be used for algorithm agility.
 
-Users SHOULD use a _cryptographic_ digest, but MAY use another identifier
-if the underlying implementation ensures immutability via other means.
+Users SHOULD use a *cryptographic* digest, but MAY use another identifier if the
+underlying implementation ensures immutability via other means.
 
 ### Supported algorithms
 
@@ -36,11 +35,11 @@ for cases when the method of serialization is obvious or well known.
 
 #### `dirHash`
 
-The [directory Hash1][] function, omitting the "h1:" prefix
-and output in lowercase hexadecimal instead of base64. This algorithm was
-designed for go modules but can be used to digest the _contents_ of an
-arbitrary archive or file tree. Equivalent to extracting the archive to an
-empty directory and running the following command in that directory:
+The [directory Hash1][] function, omitting the "h1:" prefix and output in
+lowercase hexadecimal instead of base64. This algorithm was designed for go
+modules but can be used to digest the *contents* of an arbitrary archive or file
+tree. Equivalent to extracting the archive to an empty directory and running the
+following command in that directory:
 
 ```bash
 find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut -f1 -d' '
@@ -48,13 +47,14 @@ find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut
 
 For example, the module dirhash
 `h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=` would be encoded as
-`{"dirHash1": "2a1bb6127fb481c60f67692e22285fb306f3c6ffe62075e0ccf674d7c3adcb8f"}`.
+`{"dirHash1":
+"2a1bb6127fb481c60f67692e22285fb306f3c6ffe62075e0ccf674d7c3adcb8f"}`.
 
 <details>
 <summary>Detailed example</summary>
 
-The go module `github.com/marklodato/go-hello-world@v0.0.1` has module
-dirhash `h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=`:
+The go module `github.com/marklodato/go-hello-world@v0.0.1` has module dirhash
+`h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=`:
 
 ```bash
 $ curl https://sum.golang.org/lookup/github.com/marklodato/go-hello-world@v0.0.1
@@ -63,8 +63,8 @@ github.com/marklodato/go-hello-world v0.0.1 h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgz
 ...
 ```
 
-To compute the dirhash by hand, first fetch the module archive and extract
-it to an empty directory:
+To compute the dirhash by hand, first fetch the module archive and extract it to
+an empty directory:
 
 ```bash
 curl -O https://proxy.golang.org/github.com/marklodato/go-hello-world/@v/v0.0.1.zip
@@ -73,8 +73,8 @@ cd tmp
 unzip ../v0.0.1.zip
 ```
 
-We can see all of the files in the directory using the first part of the
-command above:
+We can see all of the files in the directory using the first part of the command
+above:
 
 ```bash
 $ find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum
@@ -114,9 +114,9 @@ This hash is computed over `<type> SP <size> NUL <content>`, where:
 -   `NUL` is the ASCII NUL character, 0x00
 -   `<content>` is git representation of the object:
     -   For `commit`, the raw commit object ([more info][so-commit][^git-docs])
-    -   For `tree`,  the raw tree object, which is a series of
-        `<unix-octal-mode> <name> NUL <binary-digest>` entries, sorted by
-        `<name>` in the C locale ([more info][so-tree][^git-docs])
+    -   For `tree`, the raw tree object, which is a series of `<unix-octal-mode>
+        <name> NUL <binary-digest>` entries, sorted by `<name>` in the C locale
+        ([more info][so-tree][^git-docs])
     -   For `blob`, the raw file contents
     -   For `tag`, the raw tag object
 
@@ -133,19 +133,50 @@ $ printf 'Hello' | git hash-object -t blob --stdin
 
 ### Guidelines
 
-It is RECOMMENDED to use at least `sha256` for compatibility between
-producers and consumers, unless a different hash algorithm is more
-conventional (e.g. `gitCommit` for git).
+It is RECOMMENDED to use at least `sha256` for compatibility between producers
+and consumers, unless a different hash algorithm is more conventional (e.g.
+`gitCommit` for git).
 
-Consumers MUST only accept algorithms that they consider secure and MUST
-ignore unrecognized or unaccepted algorithms. For example, most
-applications SHOULD NOT accept "md5" because it lacks collision resistance.
+Consumers MUST only accept algorithms that they consider secure and MUST ignore
+unrecognized or unaccepted algorithms. For example, most applications SHOULD NOT
+accept "md5" because it lacks collision resistance.
 
-Two DigestSets SHOULD be considered matching if ANY acceptable field
-matches.
+Two DigestSets SHOULD be considered matching if ANY acceptable field matches.
 
 New algorithms MUST document how the value is encoded, e.g. URL-safe base64,
 lowercase hex, etc...
+
+### Use cases for non-cryptographic, immutable, digests
+
+Sometimes users have a need to refer to something by some other immutable
+identifier. Either because the content can't be hashed traditionally, because
+it's impractical to hash traditionally, or because they interact with the
+content through an interface that doesn't expose them to the entirety of the
+content.
+
+In these situations users may wish to use other identifiers in a DigestSet.
+Those users should be careful to understand the trust that they're placing in
+the identifier to be sure that it meets their needs.
+
+One concrete example of where a non-cryptographic hash can be useful is when
+referring to Virtual Machine images. Often these images are very large
+(impractical to run a cryptographic hash over) and users often interact with
+them via APIs that the platform provides that don't involve the user having
+complete custody of the content. Platforms like AWS and GCP provide 'ids' for
+users to use when referring to these images. A user may say something like
+"create an instance with image 123". In that case the user doesn't actually have
+the bits that correspond to 'image 123' so they cannot digest it themselves. And
+by the time the image has started it can be difficult, if not impossible, to
+digest the original content that was used to boot the instance.
+
+These IDs can often be treated as immutable and may be perfectly suited to users
+threat profiles. Allowing DigestSets to use these types of identifiers allows
+providers to make statements about the content of these VM images using the
+identifiers their users have ready access to.
+
+In addition, using an ID like this does not preclude including a cryptographic
+hash in the DigestSet as well. If possible including both may provide the most
+flexibility for the user's various use cases.
 
 ## Examples
 
@@ -155,15 +186,15 @@ lowercase hex, etc...
 
 <!-- Add a horizontal rule to separate footnotes -->
 
----
+--------------------------------------------------------------------------------
 
 [^git-docs]: At the time of writing (2023-03), git has no official documentation
     of the internal object format used for hashing. The [Git Objects]
-    chapter of the Git Book is the closest thing to official documentation, but
-    it lacks many details, such as the raw tree object format. The best
-    documentation we have found are the linked Stack Overflow articles. If you
-    can find a better, more official reference, please open an issue.
-
+    chapter of the Git Book is the closest thing to official
+    documentation, but it lacks many details, such as the raw tree
+    object format. The best documentation we have found are the linked
+    Stack Overflow articles. If you can find a better, more official
+    reference, please open an issue.
 [Git Objects]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 [directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go
 [so-commit]: https://stackoverflow.com/a/37438460

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -1,7 +1,5 @@
 # DigestSet field type specification
 
-Version: v1.1
-
 Set of one or more cryptographic digests, or other immutable references,
 for a single software artifact or metadata object.
 
@@ -187,17 +185,6 @@ flexibility for the user's various use cases.
 -   `{"sha256": "abcd", "sha512": "1234"}` matches `{"sha256": "abcd"}`
 -   `{"sha256": "abcd"}` does not match `{"sha256": "fedb", "sha512": "abcd"}`
 -   `{"somecoolhash": "abcd"}` uses a non-predefined algorithm
-
-## Change History
-
-### v1.1
-
-Clarified that it is acceptable to use a non-cryptographic digest (though
-cryptographic digests are still preferred).
-
-### v1.0
-
-Initial
 
 <!-- Add a horizontal rule to separate footnotes -->
 

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -195,6 +195,7 @@ flexibility for the user's various use cases.
     object format. The best documentation we have found are the linked
     Stack Overflow articles. If you can find a better, more official
     reference, please open an issue.
+
 [Git Objects]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 [directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go
 [so-commit]: https://stackoverflow.com/a/37438460

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -199,7 +199,6 @@ cryptographic digests are still preferred).
 
 Initial
 
-
 <!-- Add a horizontal rule to separate footnotes -->
 
 ---

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -29,9 +29,6 @@ algorithm to achieve this immutability. See [Use cases for non-cryptographic,
 immutable, digests](#use-cases-for-non-cryptographic-immutable-digests) for
 further guidance.
 
-Users SHOULD use a _cryptographic_ digest, but MAY use another identifier
-if the underlying implementation ensures immutability via other means.
-
 ### Supported algorithms
 
 #### `sha256`, `sha224`, `sha384`, `sha512`, `sha512_224`, `sha512_256`, `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, `shake128`, `shake256`, `blake2b`, `blake2s`, `ripemd160`, `sm3`, `gost`, `sha1`, `md5`
@@ -158,8 +155,8 @@ lowercase hex, etc...
 While cryptographic digests are the strongly recommended immutable identifier,
 users might have need to refer to an artifact by some other means. For example,
 it might be technically infeasible to compute a digest over the content, or
-because the user might interact with the content through an interface that
-doesn't expose them to the entirety of the content.
+the user might interact with the content through an interface that doesn't
+expose them to the entirety of the content.
 
 In these situations, users MAY use a non-cryptographic identifier in a DigestSet
 so long as the risk of the object being mutated is acceptable for the
@@ -190,6 +187,18 @@ flexibility for the user's various use cases.
 -   `{"sha256": "abcd", "sha512": "1234"}` matches `{"sha256": "abcd"}`
 -   `{"sha256": "abcd"}` does not match `{"sha256": "fedb", "sha512": "abcd"}`
 -   `{"somecoolhash": "abcd"}` uses a non-predefined algorithm
+
+## Change History
+
+### v1.1
+
+Clarified that it is acceptable to use a non-cryptographic digest (though
+cryptographic digests are still preferred).
+
+### v1.0
+
+Initial
+
 
 <!-- Add a horizontal rule to separate footnotes -->
 

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -26,7 +26,7 @@ agility.
 Each entry in a DigestSet MUST be an immutable reference to an artifact. It is
 STRONGLY RECOMMENDED to use a commonly accepted, cryptographically secure digest
 algorithm to achieve this immutability. See [Use cases for non-cryptographic,
-immutable, digests][use-cases-for-non-cryptographic-immutable-digests] for
+immutable, digests](#use-cases-for-non-cryptographic-immutable-digests) for
 further guidance.
 
 Users SHOULD use a _cryptographic_ digest, but MAY use another identifier

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -147,6 +147,38 @@ matches.
 New algorithms MUST document how the value is encoded, e.g. URL-safe base64,
 lowercase hex, etc...
 
+### Use cases for non-cryptographic, immutable, digests
+
+Sometimes users have a need to refer to something by some other immutable
+identifier. Either because the content can't be hashed traditionally, because
+it's impractical to hash traditionally, or because they interact with the
+content through an interface that doesn't expose them to the entirety of the
+content.
+
+In these situations users may wish to use other identifiers in a DigestSet.
+Those users should be careful to understand the trust that they're placing in
+the identifier to be sure that it meets their needs.
+
+One concrete example of where a non-cryptographic hash can be useful is when
+referring to Virtual Machine images. Often these images are very large
+(impractical to run a cryptographic hash over) and users often interact with
+them via APIs that the platform provides that don't involve the user having
+complete custody of the content. Platforms like AWS and GCP provide 'ids' for
+users to use when referring to these images. A user may say something like
+"create an instance with image 123". In that case the user doesn't actually have
+the bits that correspond to 'image 123' so they cannot digest it themselves. And
+by the time the image has started it can be difficult, if not impossible, to
+digest the original content that was used to boot the instance.
+
+These IDs can often be treated as immutable and may be perfectly suited to users
+threat profiles. Allowing DigestSets to use these types of identifiers allows
+providers to make statements about the content of these VM images using the
+identifiers their users have ready access to.
+
+In addition, using an ID like this does not preclude including a cryptographic
+hash in the DigestSet as well. If possible including both may provide the most
+flexibility for the user's various use cases.
+
 ## Examples
 
 -   `{"sha256": "abcd", "sha512": "1234"}` matches `{"sha256": "abcd"}`

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -2,8 +2,8 @@
 
 Version: v1.1
 
-Set of one or more immutable digests for a single software artifact or metadata
-object.
+Set of one or more immutable digests for a single software artifact or
+metadata object.
 
 ## Schema
 
@@ -11,19 +11,20 @@ object.
 {
   "<ALGORITHM_1>": "<VALUE>",
   "<ALGORITHM_2>": "<VALUE>",
-  ...
+  ... 
 }
 ```
 
 ## Fields
 
-A DigestSet is represented as a *JSON object* mapping algorithm name to a string
-encoding of the digest using that algorithm. The named standard algorithms below
-use lowercase hex encoding. Usually there is just a single key/value pair, but
-multiple entries MAY be used for algorithm agility.
+A DigestSet is represented as a _JSON object_ mapping algorithm name to
+a string encoding of the digest using that algorithm. The named standard
+algorithms below use lowercase hex encoding. Usually there is just a
+single key/value pair, but multiple entries MAY be used for algorithm
+agility.
 
-Users SHOULD use a *cryptographic* digest, but MAY use another identifier if the
-underlying implementation ensures immutability via other means.
+Users SHOULD use a _cryptographic_ digest, but MAY use another identifier
+if the underlying implementation ensures immutability via other means.
 
 ### Supported algorithms
 
@@ -35,11 +36,11 @@ for cases when the method of serialization is obvious or well known.
 
 #### `dirHash`
 
-The [directory Hash1][] function, omitting the "h1:" prefix and output in
-lowercase hexadecimal instead of base64. This algorithm was designed for go
-modules but can be used to digest the *contents* of an arbitrary archive or file
-tree. Equivalent to extracting the archive to an empty directory and running the
-following command in that directory:
+The [directory Hash1][] function, omitting the "h1:" prefix
+and output in lowercase hexadecimal instead of base64. This algorithm was
+designed for go modules but can be used to digest the _contents_ of an
+arbitrary archive or file tree. Equivalent to extracting the archive to an
+empty directory and running the following command in that directory:
 
 ```bash
 find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut -f1 -d' '
@@ -47,14 +48,13 @@ find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum | cut
 
 For example, the module dirhash
 `h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=` would be encoded as
-`{"dirHash1":
-"2a1bb6127fb481c60f67692e22285fb306f3c6ffe62075e0ccf674d7c3adcb8f"}`.
+`{"dirHash1": "2a1bb6127fb481c60f67692e22285fb306f3c6ffe62075e0ccf674d7c3adcb8f"}`.
 
 <details>
 <summary>Detailed example</summary>
 
-The go module `github.com/marklodato/go-hello-world@v0.0.1` has module dirhash
-`h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=`:
+The go module `github.com/marklodato/go-hello-world@v0.0.1` has module
+dirhash `h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgzPZ018Oty48=`:
 
 ```bash
 $ curl https://sum.golang.org/lookup/github.com/marklodato/go-hello-world@v0.0.1
@@ -63,8 +63,8 @@ github.com/marklodato/go-hello-world v0.0.1 h1:Khu2En+0gcYPZ2kuIihfswbzxv/mIHXgz
 ...
 ```
 
-To compute the dirhash by hand, first fetch the module archive and extract it to
-an empty directory:
+To compute the dirhash by hand, first fetch the module archive and extract
+it to an empty directory:
 
 ```bash
 curl -O https://proxy.golang.org/github.com/marklodato/go-hello-world/@v/v0.0.1.zip
@@ -73,8 +73,8 @@ cd tmp
 unzip ../v0.0.1.zip
 ```
 
-We can see all of the files in the directory using the first part of the command
-above:
+We can see all of the files in the directory using the first part of the
+command above:
 
 ```bash
 $ find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum
@@ -114,9 +114,9 @@ This hash is computed over `<type> SP <size> NUL <content>`, where:
 -   `NUL` is the ASCII NUL character, 0x00
 -   `<content>` is git representation of the object:
     -   For `commit`, the raw commit object ([more info][so-commit][^git-docs])
-    -   For `tree`, the raw tree object, which is a series of `<unix-octal-mode>
-        <name> NUL <binary-digest>` entries, sorted by `<name>` in the C locale
-        ([more info][so-tree][^git-docs])
+    -   For `tree`,  the raw tree object, which is a series of
+        `<unix-octal-mode> <name> NUL <binary-digest>` entries, sorted by
+        `<name>` in the C locale ([more info][so-tree][^git-docs])
     -   For `blob`, the raw file contents
     -   For `tag`, the raw tag object
 
@@ -133,50 +133,19 @@ $ printf 'Hello' | git hash-object -t blob --stdin
 
 ### Guidelines
 
-It is RECOMMENDED to use at least `sha256` for compatibility between producers
-and consumers, unless a different hash algorithm is more conventional (e.g.
-`gitCommit` for git).
+It is RECOMMENDED to use at least `sha256` for compatibility between
+producers and consumers, unless a different hash algorithm is more
+conventional (e.g. `gitCommit` for git).
 
-Consumers MUST only accept algorithms that they consider secure and MUST ignore
-unrecognized or unaccepted algorithms. For example, most applications SHOULD NOT
-accept "md5" because it lacks collision resistance.
+Consumers MUST only accept algorithms that they consider secure and MUST
+ignore unrecognized or unaccepted algorithms. For example, most
+applications SHOULD NOT accept "md5" because it lacks collision resistance.
 
-Two DigestSets SHOULD be considered matching if ANY acceptable field matches.
+Two DigestSets SHOULD be considered matching if ANY acceptable field
+matches.
 
 New algorithms MUST document how the value is encoded, e.g. URL-safe base64,
 lowercase hex, etc...
-
-### Use cases for non-cryptographic, immutable, digests
-
-Sometimes users have a need to refer to something by some other immutable
-identifier. Either because the content can't be hashed traditionally, because
-it's impractical to hash traditionally, or because they interact with the
-content through an interface that doesn't expose them to the entirety of the
-content.
-
-In these situations users may wish to use other identifiers in a DigestSet.
-Those users should be careful to understand the trust that they're placing in
-the identifier to be sure that it meets their needs.
-
-One concrete example of where a non-cryptographic hash can be useful is when
-referring to Virtual Machine images. Often these images are very large
-(impractical to run a cryptographic hash over) and users often interact with
-them via APIs that the platform provides that don't involve the user having
-complete custody of the content. Platforms like AWS and GCP provide 'ids' for
-users to use when referring to these images. A user may say something like
-"create an instance with image 123". In that case the user doesn't actually have
-the bits that correspond to 'image 123' so they cannot digest it themselves. And
-by the time the image has started it can be difficult, if not impossible, to
-digest the original content that was used to boot the instance.
-
-These IDs can often be treated as immutable and may be perfectly suited to users
-threat profiles. Allowing DigestSets to use these types of identifiers allows
-providers to make statements about the content of these VM images using the
-identifiers their users have ready access to.
-
-In addition, using an ID like this does not preclude including a cryptographic
-hash in the DigestSet as well. If possible including both may provide the most
-flexibility for the user's various use cases.
 
 ## Examples
 
@@ -186,15 +155,14 @@ flexibility for the user's various use cases.
 
 <!-- Add a horizontal rule to separate footnotes -->
 
---------------------------------------------------------------------------------
+---
 
 [^git-docs]: At the time of writing (2023-03), git has no official documentation
     of the internal object format used for hashing. The [Git Objects]
-    chapter of the Git Book is the closest thing to official
-    documentation, but it lacks many details, such as the raw tree
-    object format. The best documentation we have found are the linked
-    Stack Overflow articles. If you can find a better, more official
-    reference, please open an issue.
+    chapter of the Git Book is the closest thing to official documentation, but
+    it lacks many details, such as the raw tree object format. The best
+    documentation we have found are the linked Stack Overflow articles. If you
+    can find a better, more official reference, please open an issue.
 
 [Git Objects]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 [directory Hash1]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -1,16 +1,16 @@
 # DigestSet field type specification
 
-Version: v1.0
+Version: v1.1
 
-Set of one or more cryptographic digests for a single software artifact or
+Set of one or more immutable digests for a single software artifact or
 metadata object.
 
 ## Schema
 
 ```json
 {
-  "<ALGORITHM_1>": "<HEX/BASE64 VALUE>",
-  "<ALGORITHM_2>": "<HEX/BASE64 VALUE>",
+  "<ALGORITHM_1>": "<VALUE>",
+  "<ALGORITHM_2>": "<VALUE>",
   ... 
 }
 ```
@@ -22,6 +22,9 @@ a string encoding of the digest using that algorithm. The named standard
 algorithms below use lowercase hex encoding. Usually there is just a
 single key/value pair, but multiple entries MAY be used for algorithm
 agility.
+
+Users SHOULD use a _cryptographic_ digest, but MAY use another identifier 
+if the underlying implementation ensures immutability via other means.
 
 ### Supported algorithms
 

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -2,8 +2,8 @@
 
 Version: v1.1
 
-Set of one or more immutable digests for a single software artifact or
-metadata object.
+Set of one or more cryptographic digests, or other immutable references,
+for a single software artifact or metadata object.
 
 ## Schema
 
@@ -22,6 +22,12 @@ a string encoding of the digest using that algorithm. The named standard
 algorithms below use lowercase hex encoding. Usually there is just a
 single key/value pair, but multiple entries MAY be used for algorithm
 agility.
+
+Each entry in a DigestSet MUST be an immutable reference to an artifact. It is
+STRONGLY RECOMMENDED to use a commonly accepted, cryptographically secure digest
+algorithm to achieve this immutability. See [Use cases for non-cryptographic,
+immutable, digests][use-cases-for-non-cryptographic-immutable-digests] for
+further guidance.
 
 Users SHOULD use a _cryptographic_ digest, but MAY use another identifier
 if the underlying implementation ensures immutability via other means.
@@ -149,15 +155,15 @@ lowercase hex, etc...
 
 ### Use cases for non-cryptographic, immutable, digests
 
-Sometimes users have a need to refer to something by some other immutable
-identifier. Either because the content can't be hashed traditionally, because
-it's impractical to hash traditionally, or because they interact with the
-content through an interface that doesn't expose them to the entirety of the
-content.
+While cryptographic digests are the strongly recommended immutable identifier,
+users might have need to refer to an artifact by some other means. For example,
+it might be technically infeasible to compute a digest over the content, or
+because the user might interact with the content through an interface that
+doesn't expose them to the entirety of the content.
 
-In these situations users may wish to use other identifiers in a DigestSet.
-Those users should be careful to understand the trust that they're placing in
-the identifier to be sure that it meets their needs.
+In these situations, users MAY use a non-cryptographic identifier in a DigestSet
+so long as the risk of the object being mutated is acceptable for the
+application.
 
 One concrete example of where a non-cryptographic hash can be useful is when
 referring to Virtual Machine images. Often these images are very large

--- a/spec/v1/predicate.md
+++ b/spec/v1/predicate.md
@@ -1,7 +1,5 @@
 # Predicate layer specification
 
-Version: v1.0
-
 The Predicate is the innermost layer of the attestation, containing arbitrary
 metadata about the [Statement]'s `subject`.
 

--- a/spec/v1/resource_descriptor.md
+++ b/spec/v1/resource_descriptor.md
@@ -1,7 +1,5 @@
 # ResourceDescriptor field type specification
 
-Version: v1.0
-
 A size-efficient description of any software artifact or resource (mutable
 or immutable).
 

--- a/spec/v1/statement.md
+++ b/spec/v1/statement.md
@@ -1,7 +1,5 @@
 # Statement layer specification
 
-Version: v1.1
-
 The Statement is the middle layer of the attestation, binding it to a
 particular subject and unambiguously identifying the types of the
 [Predicate].
@@ -66,16 +64,6 @@ Additional [parsing rules] apply.
 > Additional parameters of the [Predicate]. Unset is treated the same as
 > set-but-empty. MAY be omitted if `predicateType` fully describes the
 > predicate.
-
-## Change History
-
-### v1.1
-
-Clarified that subjects are assumed to be immutable.
-
-### v1.0
-
-Initial
 
 [ResourceDescriptor]: resource_descriptor.md
 [JSON]: https://www.json.org/json-en.html

--- a/spec/v1/statement.md
+++ b/spec/v1/statement.md
@@ -70,6 +70,7 @@ Additional [parsing rules] apply.
 ## Change History
 
 ### v1.1
+
 Clarified that subjects are assumed to be immutable.
 
 ### v1.0

--- a/spec/v1/statement.md
+++ b/spec/v1/statement.md
@@ -38,7 +38,7 @@ Additional [parsing rules] apply.
 > Set of software artifacts that the attestation applies to. Each element
 > represents a single software artifact. Each element MUST have `digest` set.
 >
-> Subjects are assumed to me _immutable_, i.e. the artifacts identified by the
+> Subjects are assumed to be _immutable_, i.e. the artifacts identified by the
 > subject SHOULD NOT change.
 >
 > The `name` field may be used as an identifier to distinguish this artifact
@@ -66,6 +66,15 @@ Additional [parsing rules] apply.
 > Additional parameters of the [Predicate]. Unset is treated the same as
 > set-but-empty. MAY be omitted if `predicateType` fully describes the
 > predicate.
+
+## Change History
+
+### v1.1
+Clarified that subjects are assumed to be immutable.
+
+### v1.0
+
+Initial
 
 [ResourceDescriptor]: resource_descriptor.md
 [JSON]: https://www.json.org/json-en.html

--- a/spec/v1/statement.md
+++ b/spec/v1/statement.md
@@ -1,6 +1,6 @@
 # Statement layer specification
 
-Version: v1.0
+Version: v1.1
 
 The Statement is the middle layer of the attestation, binding it to a
 particular subject and unambiguously identifying the types of the
@@ -37,6 +37,9 @@ Additional [parsing rules] apply.
 
 > Set of software artifacts that the attestation applies to. Each element
 > represents a single software artifact. Each element MUST have `digest` set.
+>
+> Subjects are assumed to me _immutable_, i.e. the artifacts identified by the
+> subject SHOULD NOT change.
 >
 > The `name` field may be used as an identifier to distinguish this artifact
 > from others within the `subject`. Similarly, other ResourceDescriptor fields


### PR DESCRIPTION
There are uses for DigestSets that don't involve cryptographic hashes and I don't think we ever meant to preclude those uses?

(This PR motivated by [this discussion](https://github.com/in-toto/attestation/pull/330/commits/e8c06cf62050b96daf4ef356bf382f4680a07be3#r1511872856) and another I've had with @laurentsimon).

Sometimes users have a need to refer to something by some other immutable identifier.  Either because the content can't be hashed traditionally, because it's impractical to hash traditionally, or because they interact with the content through an interface that doesn't expose them to the entirety of the content.

In these situations users may wish to use other identifiers in a DigestSet.  Those users should be careful to understand the trust that they're placing in the identifier to be sure that it meets their needs.

One concrete example of where a non-cryptographic hash can be useful is when referring to Virtual Machine images.  Often these images are very large (so impractical to run a cryptographic hash over) and users often interact with them via APIs that the platform provides that don't involve the user having complete custody of the content.  Platforms like AWS and GCP provide 'ids' for users to use when referring to these images.  A user may say something like "create an instance with image 123".  In that case the user doesn't actually have the bits that correspond to 'image 123' so they cannot digest it themselves.  And by the time the image has started it can be difficult, if not impossible, to digest the original content that was used to boot the instance (this is probably a good use case for secure boot, but is out of scope here :)).

These IDs can often be treated as immutable and may be perfectly suited to users threat profiles.  Allowing DigestSets to use these types of identifiers would allow providers to make statements about the content of these VM images using the identifiers their users have ready access to.

In addition, using an ID like this does not preclude including a cryptographic hash in the DigestSet _as well_. If possible including both may provide the most flexibility for the user's various use cases.