### PR TITLE
Fix broken links to ResourceDescriptor

### DIFF
--- a/spec/predicates/link.md
+++ b/spec/predicates/link.md
@@ -136,6 +136,6 @@ def convert(statement):
 <!-- TODO: Fix link-->
 
 [in-toto specification]: https://github.com/in-toto/docs/blob/master/in-toto-spec.md
-[ResourceDescriptor]: ../v1.0/resource_descriptor.md
+[ResourceDescriptor]: ../v1/resource_descriptor.md
 [Provenance]: provenance.md
 [ITE-4]: https://github.com/in-toto/ITE/blob/master/ITE/4/README.adoc

--- a/spec/predicates/test-result.md
+++ b/spec/predicates/test-result.md
@@ -87,7 +87,7 @@ tested.
 ### Parsing Rules
 
 This predicate follows the
-[in-toto Attestation Framework's parsing rules](../v1.0/README.md#parsing-rules).
+[in-toto Attestation Framework's parsing rules](../v1/README.md#parsing-rules).
 
 ### Fields
 


### PR DESCRIPTION
There exist two broken links to resource descriptor in the repo pointing to a `/spec/v1.0` directory which doesn't exist. Fixed these references.
