### PR TITLE
Simplify SCAI predicate TypeURI

### DIFF
--- a/go/predicates/scai/v0/scai.go
+++ b/go/predicates/scai/v0/scai.go
@@ -6,6 +6,9 @@ package v0
 
 import "fmt"
 
+const PredicateTypeUri = "https://in-toto.io/attestation/scai/"
+const PredicateVersion = "v0.3"
+
 func (a *AttributeAssertion) Validate() error {
 	// at least the attribute field is required
 	if a.GetAttribute() == "" {

--- a/python/Makefile
+++ b/python/Makefile
@@ -37,7 +37,7 @@ $(VENV_STAMP): pyproject.toml
 .PHONY: lint
 lint: $(VENV_STAMP)
 	. $(VENV_BIN)/activate && \
-		ruff format --check $(ALL_PY_SRCS) && \
+		ruff format --diff $(ALL_PY_SRCS) && \
 		ruff check $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE)
 

--- a/python/in_toto_attestation/predicates/scai/v0/scai.py
+++ b/python/in_toto_attestation/predicates/scai/v0/scai.py
@@ -6,6 +6,7 @@ from in_toto_attestation.v1.resource_descriptor import ResourceDescriptor
 SCAI_PREDICATE_TYPE = "https://in-toto.io/attestation/scai/"
 SCAI_PREDICATE_VERSION = "v0.3"
 
+
 class AttributeAssertion:
     def __init__(self, attribute, target=None, conditions=None, evidence=None) -> None:
         self.pb = scaipb.AttributeAssertion()  # type: ignore[attr-defined]

--- a/python/in_toto_attestation/predicates/scai/v0/scai.py
+++ b/python/in_toto_attestation/predicates/scai/v0/scai.py
@@ -3,9 +3,8 @@
 import in_toto_attestation.predicates.scai.v0.scai_pb2 as scaipb
 from in_toto_attestation.v1.resource_descriptor import ResourceDescriptor
 
-SCAI_PREDICATE_TYPE = "https://in-toto.io/attestation/scai/attribute-report/"
-SCAI_PREDICATE_VERSION = "v0.2"
-
+SCAI_PREDICATE_TYPE = "https://in-toto.io/attestation/scai/"
+SCAI_PREDICATE_VERSION = "v0.3"
 
 class AttributeAssertion:
     def __init__(self, attribute, target=None, conditions=None, evidence=None) -> None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,10 +45,8 @@ path = "in_toto_attestation/__init__.py"
 [tool.hatch.build.targets.sdist]
 include = ["/in_toto_attestation"]
 
-[tool.ruff]
-select = ["E", "F", "I", "UP", "W"]
-
 [tool.ruff.lint]
+select = ["E", "F", "I", "UP", "W"]
 ignore = [
     # protobuf generates non-top-level imports.
     "E402",

--- a/spec/predicates/scai.md
+++ b/spec/predicates/scai.md
@@ -1,8 +1,8 @@
 # Predicate type: Software Supply Chain Attribute Integrity (SCAI)
 
-Type URI: https://in-toto.io/attestation/scai/attribute-report
+Type URI: https://in-toto.io/attestation/scai
 
-Version: 0.2
+Version: 0.3
 
 Author: Marcela Melara ([@marcelamelara](https://github.com/marcelamelara))
 
@@ -99,7 +99,7 @@ together in a SCAI Attribute Report predicate.
 
 ```jsonc
 {
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "<ATTRIBUTE>",
@@ -136,7 +136,7 @@ The following parsing rules apply in addition:
 `predicateType` _string ([TypeURI]), required_
 
 > Identifier for the schema of the Attribute Report. Always
-> `https://in-toto.io/attestation/scai/attribute-report/v0.2` for this version of the
+> `https://in-toto.io/attestation/scai/v0.3` for this version of the
 > spec.
 
 `predicate.attributes` _array of objects, required_
@@ -197,7 +197,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "78ab6a8..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "WITH_STACK_PROTECTION",
@@ -226,7 +226,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "78ab6a8..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "WITH_STACK_PROTECTION",
@@ -256,7 +256,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "78ab6a8..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "WITH_STACK_PROTECTION",
@@ -290,7 +290,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "78ab6a8..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "ATTESTED_DEPENDENCIES",
@@ -323,7 +323,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "78ab6a8..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2"
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3"
     "predicate": {
         "attributes": [{
             "attribute": "VALID_ENCLAVE",
@@ -354,7 +354,7 @@ The following parsing rules apply in addition:
         "digest": { "sha256": "88888888..." }
     }],
         
-    "predicateType": "https://in-toto.io/attestation/scai/attribute-report/v0.2",
+    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
             "attribute": "attestation-1",
@@ -387,6 +387,10 @@ The following parsing rules apply in addition:
 
 ## Changelog and Migrations
 
+### New in v0.3
+
+-   Simplify the predicate `TypeURI` suffix from `/scai/attribute-report` to `/scai` per the latest [predicate naming convention].
+
 ### New in v0.2
 
 -   Change the `target` and `evidence` field type of a SCAI Attribute
@@ -399,3 +403,4 @@ The following parsing rules apply in addition:
 [TypeURI]: ../v1/field_types.md#typeuri
 [attestation Bundle]: ../v1/bundle.md
 [parsing rules]: ../v1#parsing-rules
+[predicate naming convention]: ../../docs/new_predicate_guidelines.md#vetting-process


### PR DESCRIPTION
Unlike the [recommended naming convention](https://github.com/in-toto/attestation/blob/main/docs/new_predicate_guidelines.md#vetting-process), the SCAI predicate TypeURI has an extra element `/attribute-report`. This may confusingly signal other types of SCAI predicates, which don't exist AFAIK, and is therefore redundant. This PR makes the type URI conform with the expected convention, and bumps the minor version.

Related to #371 .