### PR TITLE
Update link to SLSA framework proto file

### DIFF
--- a/protos/in_toto_attestation/predicates/provenance/v1/provenance.proto
+++ b/protos/in_toto_attestation/predicates/provenance/v1/provenance.proto
@@ -1,4 +1,4 @@
-// Keep in sync with schema at https://github.com/slsa-framework/slsa/blob/main/docs/provenance/schema/v1/provenance.proto
+// Keep in sync with schema at https://github.com/slsa-framework/slsa/blob/main/docs/spec/v1.0/schema/provenance.proto
 syntax = "proto3";
 
 package in_toto_attestation.predicates.provenance.v1;


### PR DESCRIPTION
Update the comment to point to the updated location of the v1.0 provenance proto file in the SLSA framework repository

This file was moved to a new location in the repository last month as part of https://github.com/slsa-framework/slsa/pull/939/files#diff-0d74b135d4a3da2b4ed73c88a4566d07e465dd6aee46f46f45e0ffbb7c232128