### PR TITLE
Adds custom marshal/unmarshal to Go Statement struct, fixes #363, see sigstore/sigstore-go#326

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/in-toto/attestation
 
-go 1.20
+go 1.21
+
+toolchain go1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go/v1/statement.go
+++ b/go/v1/statement.go
@@ -4,7 +4,11 @@ Wrapper APIs for in-toto attestation Statement layer protos.
 
 package v1
 
-import "errors"
+import (
+	"errors"
+
+	"google.golang.org/protobuf/encoding/protojson"
+)
 
 const StatementTypeUri = "https://in-toto.io/Statement/v1"
 
@@ -47,4 +51,12 @@ func (s *Statement) Validate() error {
 	}
 
 	return nil
+}
+
+func (s *Statement) MarshalJSON() ([]byte, error) {
+	return protojson.Marshal(s)
+}
+
+func (s *Statement) UnmarshalJSON(data []byte) error {
+	return protojson.Unmarshal(data, s)
 }

--- a/go/v1/statement_test.go
+++ b/go/v1/statement_test.go
@@ -5,6 +5,7 @@ Tests for in-toto attestation ResourceDescriptor protos.
 package v1
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -39,7 +40,7 @@ func createTestStatement(t *testing.T) *Statement {
 	}
 }
 
-func TestJsonUnmarshalStatement(t *testing.T) {
+func TestProtojsonUnmarshalStatement(t *testing.T) {
 	var wantSt = `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
 
 	got := &Statement{}
@@ -47,8 +48,36 @@ func TestJsonUnmarshalStatement(t *testing.T) {
 	assert.NoError(t, err, "error during JSON unmarshalling")
 
 	want := createTestStatement(t)
-	assert.NoError(t, err, "unexpected error during test Statement creation")
 	assert.True(t, proto.Equal(got, want), "protos do not match")
+}
+
+func TestJsonUnmarshalStatement(t *testing.T) {
+	var wantSt = `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
+
+	got := &Statement{}
+	err := json.Unmarshal([]byte(wantSt), got)
+	assert.NoError(t, err, "error during JSON unmarshalling")
+
+	want := createTestStatement(t)
+	assert.True(t, proto.Equal(got, want), "protos do not match")
+}
+
+func TestProtojsonMarshalStatement(t *testing.T) {
+	var wantSt = `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
+	want := createTestStatement(t)
+
+	gotSt, err := protojson.Marshal(want)
+	assert.NoError(t, err, "error during JSON marshalling")
+	assert.JSONEq(t, wantSt, string(gotSt), "JSON objects do not match")
+}
+
+func TestJsonMarshalStatement(t *testing.T) {
+	var wantSt = `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
+	want := createTestStatement(t)
+
+	gotSt, err := json.Marshal(want)
+	assert.NoError(t, err, "error during JSON marshalling")
+	assert.JSONEq(t, wantSt, string(gotSt), "JSON objects do not match")
 }
 
 func TestBadStatementType(t *testing.T) {
@@ -61,6 +90,8 @@ func TestBadStatementType(t *testing.T) {
 	err = got.Validate()
 	assert.ErrorIs(t, err, ErrInvalidStatementType, "created malformed Statement (bad type)")
 }
+
+
 
 func TestBadStatementSubject(t *testing.T) {
 	tests := map[string]struct {
@@ -122,3 +153,4 @@ func TestBadStatementPredicate(t *testing.T) {
 		assert.ErrorIs(t, err, test.err, fmt.Sprintf("%s in test '%s'", test.noErrMessage, name))
 	}
 }
+


### PR DESCRIPTION
This PR adds custom marshaler and unmarshaler to the statement struct to help users avoid incorrectly serializing in-toto statements. This fixes #363 and stems from a discussion in sigstore/sigstore-go#326s