### PR TITLE
vsa: Make verifiedLevels field repeated to match spec

### DIFF
--- a/protos/in_toto_attestation/predicates/vsa/v1/vsa.proto
+++ b/protos/in_toto_attestation/predicates/vsa/v1/vsa.proto
@@ -33,7 +33,7 @@ message VerificationSummary {
   repeated InputAttestation input_attestations = 5 [json_name = "inputAttestations"];
 
   string verification_result = 6 [json_name = "verificationResult"];
-  string verified_levels = 7 [json_name = "verifiedLevels"];
+  repeated string verified_levels = 7 [json_name = "verifiedLevels"];
   map<string, uint64> dependency_levels = 8 [json_name = "dependencyLevels"];
   string slsa_version = 9 [json_name = "slsaVersion"];
 }


### PR DESCRIPTION
The specification requires the verifiedLevels field to be a list of string values rather than a single string.

Fixes #425 