### PR TITLE
VulnsV2: Add missing invocation to protos and spec

### DIFF
--- a/protos/in_toto_attestation/predicates/vulns/v0.2/vulns.proto
+++ b/protos/in_toto_attestation/predicates/vulns/v0.2/vulns.proto
@@ -11,13 +11,13 @@ option java_package = "io.github.intoto.attestation.predicates.vulns.v02";
 // Validation of all fields is left to the users of this proto.
 message Vulns {
   Scanner scanner = 1;
-  ScanMetadata scan_metadata = 2;
+  ScanMetadata metadata = 2;
 }
 
 message Scanner {
   string uri = 1;
   optional string version = 2;
-  VulnDatabase database = 3;
+  VulnDatabase db = 3;
   repeated Result result = 4;
 }
 

--- a/spec/predicates/vulns_02.md
+++ b/spec/predicates/vulns_02.md
@@ -135,7 +135,7 @@ The `predicate` contains a JSON-encoded data with the following fields:
          "id": "CVE-123",
          "severity": [
           { "method": "nvd", "score": "medium"},
-          { "method": "cvss_score", "score", "5.2" }
+          { "method": "cvss_score", "score": "5.2" }
          ]
         },
         {...}


### PR DESCRIPTION
This PR updates the vulns02 protos to rename the `scanner.database` field (to `scanner.db`) and the `scanner_metadata` field (to just `metadata`) to match the vulns02 spec.


Sample generated predicate (with the go library):

```json
{
  "scanner": {
    "uri": "pkg:github/aquasecurity/trivy@244fd47e07d1004f0aed9",
    "version": "0.19.2",
    "db": {
      "uri": "pkg:github/aquasecurity/trivy-db/commit/4c76bb580b2736d67751410fa4ab66d2b6b9b27d",
      "version": "v1-2021080612",
      "last_update": {
        "seconds": 1737495873,
        "nanos": 773202315
      }
    },
    "result": [
      {
        "id": "CVE-123",
        "severity": [
          {
            "method": "nvd",
            "score": "medium"
          },
          {
            "method": "cvss_score",
            "score": "5.2"
          }
        ]
      }
    ]
  },
  "metadata": {
    "scan_started_on": {
      "seconds": 1737495873,
      "nanos": 773202413
    },
    "scan_finished_on": {
      "seconds": 1737495873,
      "nanos": 773202481
    }
  }
}

```

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
