### PR TITLE
ITE-12: translate data definitions to CDDL

### DIFF
--- a/spec/predicates/cyclonedx.md
+++ b/spec/predicates/cyclonedx.md
@@ -20,10 +20,22 @@ The in-toto [attestation] framework and a [CycloneDX BOM generation tool].
 
 This is a predicate type that fits within the larger [Attestation] framework.
 
-## Schema
+## Data definition
 
 The schema of this predicate type is documented in the
-[CycloneDX Specification].
+[CycloneDX Specification] for vnd.cyclonedx+json.
+
+As of 2024, CycloneDX does not have an official vnd.cyclonedx+cbor content type for CBOR encoding.
+To embed a JSON CycloneDX into the predicate, use the [`TN()` transformation] of application/json for wrapping the JSON encoding.
+
+```cddl
+cyclonedx-predicate = (
+  predicateType-label => "https://cyclonedx.org/bom/v1.4",
+  predicate-label => JC<cyclonedx-map, cyclonedx-json-tunnel>
+)
+cyclonedx-map = object
+cyclonedx-json-tunnel = { &(json-embedding: -4478722) => 1668546867(bytes) }
+```
 
 ### Parsing Rules
 
@@ -75,3 +87,4 @@ Not applicable for this initial version.
 [CycloneDX Capabilities]: https://cyclonedx.org/capabilities/
 [CycloneDX Specification]: https://github.com/CycloneDX/specification/tree/1.4/schema
 [CycloneDX BOM generation tool]: https://cyclonedx.org/tool-center
+[`TN()` transformation]: https://www.rfc-editor.org/rfc/rfc9277.html#ct-tags

--- a/spec/predicates/link.md
+++ b/spec/predicates/link.md
@@ -32,24 +32,27 @@ fields.
 For every step described in the layout of the software supply chain, one (or
 more, depending on the threshold) signed link attestations must be presented.
 
-## Schema
+## Data definition
 
-```jsonc
-{
-  // Standard attestation fields:
-  "_type": "https://in-toto.io/Statement/v1",
-  "subject": [{ ... }],
+The link predicate grammar is specified in CDDL below, with some definitions from the base v1.2 in-toto specification.
 
-  // Predicate:
-  "predicateType": "https://in-toto.io/attestation/link/v0.3",
-  "predicate": {
-    "name": "...",
-    "command": [ ... ],
-    "materials": [<ResourceDescriptor>, ...],
-    "byproducts": { ... },
-    "environment": { ... }
-  }
+```cddl
+link-predicate = (
+  predicateType-label => "https://in-toto.io/attestation/link/v0.3",
+  predicate-label: link-predicate-map
+)
+link-predicate-map = {
+  link-predicate-name-label => text,
+  ? link-predicate-command-label => [ * text ],
+  ? link-predicate-materials-label => [ * ResourceDescriptor ],
+  ? link-predicate-byproducts-label => object,
+  ? link-predicate-environment-label => object
 }
+link-predicate-name-label        = JC<"name",        0>
+link-predicate-command-label     = JC<"command",     1>
+link-predicate-materials-label   = JC<"materials",   2>
+link-predicate-byproducts-label  = JC<"byproducts",  3>
+link-predicate-environment-label = JC<"environment", 4>
 ```
 
 ### Fields
@@ -126,6 +129,7 @@ def convert(statement):
 
 ## Version History
 
+-   0.3 revision: Added CDDL data description to account for CBOR representation.
 -   0.3: Updated `materials` to use a list of `ResourceDescriptor` objects.
     Reverted `command` to a list of strings to match the original link
     specification. Supports use of `ResourceDescriptor` for attestation

--- a/spec/predicates/reference.md
+++ b/spec/predicates/reference.md
@@ -37,23 +37,27 @@ This predicate is intended to be generated and consumed throughout the software
 supply chain. In addition, it is intended to be used in the analysis of it as a
 whole.
 
-## Schema
+## Data definition
 
-```jsonc
-{
-  // Standard attestation fields:
-  "_type": "https://in-toto.io/Statement/v1",
-  "subject": [{ ... }],
+The predicate grammar is provided in CDDL.
+Undefined directives are imported from the base v1.2 specification.
 
-  // Predicate:
-  "predicateType": "https://in-toto.io/attestation/reference/v0.1",
-  "predicate": {
-    "attester": {
-      "id": "<TypeUri>"
-    },
-    "references": ["<ResourceDescriptor>", ...]
-  }
+```cddl
+reference-predicate = (
+  predicateType-label => "https://in-toto.io/attestation/reference/v0.1",
+  predicate-label => reference-predicate-map
+)
+reference-predicate-map = {
+  reference-attester-label => reference-attester-map
+  reference-references-label => [ * ResourceDescriptor ]
 }
+reference-attester-label   = JC<"attester",   0>
+reference-references-label = JC<"references", 1>
+
+reference-attester-map = {
+  reference-attester-id-label => uri-type
+}
+reference-attester-id-label = JC<"id", 0>
 ```
 
 ### Parsing Rules
@@ -152,4 +156,4 @@ subjects -- it will list dependencies of both foo and bar.
 
 ## Changelog and Migrations
 
-None yet.
+Updated to include CDDL description.

--- a/spec/predicates/release.md
+++ b/spec/predicates/release.md
@@ -62,21 +62,21 @@ with artifact A, and then later has a release attestation with only artifact B,
 that SHOULD be interpreted as the release version now only containing artifact
 B.
 
-## Schema
+## Data definition
+
+The predicate grammar is provided in CDDL.
+Undefined directives are imported from the base v1.2 specification.
 
 ```jsonc
-{
-  // Standard attestation fields:
-  "_type": "https://in-toto.io/Statement/v1",
-  "subject": [{ ... }],
-
-  // Predicate:
-  "predicateType": "https://in-toto.io/attestation/release/v0.1",
-  "predicate": {
-    "purl": <ResourceURI>,
-    "releaseId": "..."
+release-predicate = (
+  predicateType-label => "https://in-toto.io/attestation/release/v0.1",
+  predicate-label: {
+    release-purl-label: uri-type,
+    release-releaseId-label => text
   }
-}
+)
+release-purl-label      = JC<"purl",      0>
+release-releaseId-label = JC<"releaseId", 1>
 ```
 
 ### Fields

--- a/spec/predicates/runtime-trace.md
+++ b/spec/predicates/runtime-trace.md
@@ -43,39 +43,57 @@ contains information that when put together uniquely identifies the exact
 instance of the job being observed. The `monitorLog` field contains the actual
 runtime trace information.
 
-## Schema
+## Data definition
 
 ```json
-{
-    "_type": "https://in-toto.io/Statement/v1",
-    "subject": [{ ... }],
-    "predicateType": "https://in-toto.io/attestation/runtime-trace/v0.1",
-    "predicate": {
-        "monitor": {
-            "type": "<TypeURI>",
-            "configSource": "<ResourceDescriptor>",
-            "tracePolicy": { /* object */ }
-        },
-        "monitoredProcess": {
-            "hostID": "<URI>",
-            "type": "<URI>",
-            "event": "<STRING>"
-        },
-        "monitorLog": {
-            "process": [
-                { /* object */ }
-            ],
-            "network": [
-                { /* object */ }
-            ],
-            "fileAccess": ["<ResourceDescriptor>", ...]
-        },
-        "metadata": {
-            "buildStartedOn": "<TIMESTAMP>",
-            "buildFinishedOn": "<TIMESTAMP>"
-        }
-    }
+rt-trace-predicate = (
+    predicateType-label => "https://in-toto.io/attestation/runtime-trace/v0.1",
+    predicate-label => rt-trace-predicate-map
+)
+rt-trace-predicate-map = {
+        rt-trace-monitor-label => rt-trace-monitor-map,
+        rt-trace-monitoredProcess-label => rt-trace-monitoredProcess-map,
+        rt-trace-monitorLog-label => rt-trace-monitorLog-map,
+        ? rt-trace-metadata-label => rt-trace-metadata-map
 }
+rt-trace-monitor-label          = JC<"monitor",          0>
+rt-trace-monitoredProcess-label = JC<"monitoredProcess", 1>
+rt-trace-monitorLog-label       = JC<"monitorLog",       2>
+rt-trace-metadata-label         = JC<"metadata",         3>
+
+rt-trace-monitor-map = {
+  rt-trace-monitor-type-label => uri-type,
+  ? rt-trace-monitor-configSource-label => ResourceDescriptor,
+  ? rt-trace-monitor-tracePolicy-label => object
+}
+rt-trace-monitor-type-label         = JC<"type",         0>
+rt-trace-monitor-configSource-label = JC<"configSource", 1>
+rt-trace-monitor-tracePolicy-label  = JC<"tracePolicy",  2>
+
+rt-trace-monitoredProcess-map {
+  rt-trace-monitoredProcess-hostID-label => uri-type,
+  rt-trace-monitoredProcess-type-label => uri-type,
+  rt-trace-monitoredProcess-event-label => text
+}
+rt-trace-monitoredProcess-hostID-label = JC<"hostID", 0>
+rt-trace-monitoredProcess-type-label   = JC<"type",   1>
+rt-trace-monitoredProcess-event-label  = JC<"event",  2>
+
+rt-trace-monitorLog-map = nonempty<{
+  ? rt-trace-monitorLog-process-label => [ * object ],
+  ? rt-trace-monitorLog-network-label => [ * object ],
+  ? rt-trace-monitorLog-fileAccess-label => [ * ResourceDescriptor ]
+}>
+rt-trace-monitorLog-process-label    = JC<"process",    0>
+rt-trace-monitorLog-network-label    = JC<"network",    1>
+rt-trace-monitorLog-fileAccess-label = JC<"fileAccess", 2>
+
+rt-trace-metadata-map = {
+  ? rt-trace-buildStartedOn-label => Timestamp,
+  ? rt-trace-buildFinishedOn-label => Timestamp
+}
+rt-trace-buildStartedOn-label  = JC<"buildStartedOn",  0>
+rt-trace-buildFinishedOn-label = JC<"buildFinishedOn", 1>
 ```
 
 ### Parsing Rules

--- a/spec/predicates/scai.md
+++ b/spec/predicates/scai.md
@@ -2,7 +2,7 @@
 
 Type URI: https://in-toto.io/attestation/scai
 
-Version: 0.3
+Version: 0.4
 
 Author: Marcela Melara ([@marcelamelara](https://github.com/marcelamelara))
 
@@ -91,25 +91,35 @@ As such, we envision SCAI metadata being explictly bound to, or included
 within, other metadata objects; we recommend an in-toto [attestation Bundle]
 for this purpose.
 
-## Schema
+## Data description
 
 The core metadata in SCAI is the Attribute Assertion. A collection of
 Attribute Assertions for a specific supply chain step or operation are issued
 together in a SCAI Attribute Report predicate.
 
-```jsonc
-{
-    "predicateType": "https://in-toto.io/attestation/scai/v0.3",
-    "predicate": {
-        "attributes": [{
-            "attribute": "<ATTRIBUTE>",
-            "target": { [ResourceDescriptor] }, // optional
-            "conditions": { /* object */ }, // optional
-            "evidence": { [ResourceDescriptor] } // optional
-        }],
-        "producer": { [ResourceDescriptor] } // optional
+The following CDDL depends on definitions from the base v1.2 in-toto specification.
+
+```cddl
+scai-predicate = (
+  predicateType-label => "https://in-toto.io/attestation/scai/v0.3",
+  predicate-label => {
+      attributes-label: [ * scai-attribute-map ],
+      ? producer-label => ResourceDescriptor
     }
+)
+scai-attributes-label = JC<"attributes", 0>
+scai-producer-label   = JC<"producer",   1>
+
+scai-attribute-map = {
+  attribute-label => text,
+  ? target-label => ResourceDescriptor,
+  ? conditions-label => object,
+  ? evidence-label => ResourceDescriptor
 }
+scai-attribute-label  = JC<"attribute",  0>
+scai-target-label     = JC<"target",     1>
+scai-conditions-label = JC<"conditions", 2>
+scai-evidence-label   = JC<"evidence",   3>
 ```
 
 This predicate has been adapted from the [SCAI specification] for greater
@@ -196,7 +206,7 @@ The following parsing rules apply in addition:
         "name": "my-app",
         "digest": { "sha256": "78ab6a8..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
@@ -225,7 +235,7 @@ The following parsing rules apply in addition:
         "name": "gcc9.3.0",
         "digest": { "sha256": "78ab6a8..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
@@ -255,7 +265,7 @@ The following parsing rules apply in addition:
         "name": "my-app",
         "digest": { "sha256": "78ab6a8..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
@@ -289,7 +299,7 @@ The following parsing rules apply in addition:
         "name": "my-app",
         "digest": { "sha256": "78ab6a8..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
@@ -322,7 +332,7 @@ The following parsing rules apply in addition:
         "name": "my-sgx-builder",
         "digest": { "sha256": "78ab6a8..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3"
     "predicate": {
         "attributes": [{
@@ -353,7 +363,7 @@ The following parsing rules apply in addition:
         "name": "app-evidence-collection",
         "digest": { "sha256": "88888888..." }
     }],
-        
+
     "predicateType": "https://in-toto.io/attestation/scai/v0.3",
     "predicate": {
         "attributes": [{
@@ -386,6 +396,10 @@ The following parsing rules apply in addition:
 ```
 
 ## Changelog and Migrations
+
+### New in v0.4
+
+-   Data description updated to use CDDL and provide more concise representation in CBOR.
 
 ### New in v0.3
 

--- a/spec/predicates/spdx.md
+++ b/spec/predicates/spdx.md
@@ -26,10 +26,22 @@ The in-toto [attestation] framework and a [SPDX generation tool].
 
 This is a predicate type that fits within the larger [Attestation] framework.
 
-## Schema
+## Data definition
 
 The schema of this predicate type is documented in the
-[SPDX Specification].
+[SPDX Specification] for application/spdx+json.
+
+As of 2024, SPDX does not have an official spdx+cbor content type for CBOR encoding.
+To embed a JSON SDX into the predicate, use the [`TN()` transformation] of application/json for wrapping the JSON encoding.
+
+```cddl
+spdx-predicate = (
+  predicateType-label => "https://spdx.dev/Document/v2.3",
+  predicate-label => JC<spdx-map, spdx-json-tunnel>
+)
+spdx-map = object
+spdx-json-tunnel = { &(json-embedding: -4478722) => 1668546867(bytes) }
+```
 
 ### Parsing Rules
 

--- a/spec/predicates/test-result.md
+++ b/spec/predicates/test-result.md
@@ -66,22 +66,37 @@ names of tests that passed with no errors or warnings, passed with warnings, and
 failed with errors respectively. The expected `subject` are the source artifacts
 tested.
 
-## Schema
+## Data definition
+
+The predicate grammar is provided in CDDL.
+Undefined directives are imported from the base v1.2 specification.
 
 ```json
-{
-    "_type": "https://in-toto.io/Statement/v1",
-    "subject": [{...}],
-    "predicateType": "https://in-toto.io/attestation/test-result/v0.1",
-    "predicate": {
-        "result": "PASSED|WARNED|FAILED",
-        "configuration": ["<ResourceDescriptor>", ...],
-        "url": "<URL>",
-        "passedTests": ["<TEST_NAME>", ...],
-        "warnedTests": ["<TEST_NAME>", ...],
-        "failedTests": ["<TEST_NAME>", ...]
-    }
+test-result-predicate = (
+  predicateType-label => "https://in-toto.io/attestation/test-result/v0.1",
+  predicate-label => test-result-predicate-map
+)
+test-result-predicate-map = {
+  test-result-result-label => test-result-result-values,
+  test-result-configuration-label => [ * ResourceDescriptor ],
+  ? test-result-url-label => uri-type,
+  ? test-result-passedTests-label => [ * text ],
+  ? test-result-warnedTests-label => [ * text ],
+  ? test-result-failedTests-label => [ * text ]
 }
+test-result-result-label = JC<"result", 0>
+test-result-configuration-label = JC<"configuration", 1>
+test-result-url-label           = JC<"url",           2>
+test-result-passedTests-label   = JC<"passedTests",   3>
+test-result-warnedTests-label   = JC<"warnedTests",   4>
+test-result-failedTests-label   = JC<"failedTests",   5>
+
+test-result-result-values /= test-result-passed
+test-result-result-values /= test-result-warned
+test-result-result-values /= test-result-failed
+test-result-passed = JC<"PASSED", 0>
+test-result-warned = JC<"WARNED", 1>
+test-result-failed = JC<"FAILED", 2>
 ```
 
 ### Parsing Rules

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -1,6 +1,6 @@
 # Specification for in-toto attestation layers
 
-Version: v1.1
+Version: v1.2
 
 Index:
 

--- a/spec/v1/digest_set.md
+++ b/spec/v1/digest_set.md
@@ -3,22 +3,52 @@
 Set of one or more cryptographic digests, or other immutable references,
 for a single software artifact or metadata object.
 
-## Schema
+## Data description
 
-```json
-{
-  "<ALGORITHM_1>": "<VALUE>",
-  "<ALGORITHM_2>": "<VALUE>",
-  ... 
-}
+```cddl
+DigestSet = nonempty<{
+  * standard-alg-id => enc-bytes,
+  * nonstandard-alg-id ^=> JC<text, bytes>
+}>
+
+standard-alg-id /= JC<"sha256", "sha256" / 1>
+standard-alg-id /= "sha224"
+standard-alg-id /= JC<"sha384", "sha384" / 7>
+standard-alg-id /= JC<"sha512", "sha512" / 8>
+standard-alg-id /= "sha512_256"
+standard-alg-id /= JC<"sha3_224", "sha3_224" / 9>
+standard-alg-id /= JC<"sha3_256", "sha3_256" / 10>
+standard-alg-id /= JC<"sha3_384", "sha3_384" / 11>
+standard-alg-id /= JC<"sha3_512", "sha3_512" / 12>
+standard-alg-id /= "shake128"
+standard-alg-id /= "shake256"
+standard-alg-id /= "blake2b"
+standard-alg-id /= "blake2s"
+standard-alg-id /= "ripemd160"
+standard-alg-id /= "sm3"
+standard-alg-id /= "gost"
+standard-alg-id /= "sha1"
+standard-alg-id /= "md5"
+standard-alg-id /= "dirHash"
+standard-alg-id /= "gitCommit"
+standard-alg-id /= "gitTree"
+standard-alg-id /= "gitBlob"
+standard-alg-id /= "gitTag"
+nonstandard-alg-id = text
+
+alg-id    = JC<text,   text / int>
+enc-bytes = JC<hexstr, bytes>
+hexstr = text .regexp "([0-9a-fA-F]{2})+"
+
+nonempty<M> = (M) .and ({ + any => any })
 ```
 
 ## Fields
 
-A DigestSet is represented as a _JSON object_ mapping algorithm name to
-a string encoding of the digest using that algorithm. The named standard
-algorithms below use lowercase hex encoding. Usually there is just a
-single key/value pair, but multiple entries MAY be used for algorithm
+A DigestSet is represented as either a _JSON object_ or _CBOR map_ mapping
+algorithm name to a string encoding of the digest using that algorithm. The
+named standard algorithms below use lowercase hex encoding. Usually there is
+just a single key/value pair, but multiple entries MAY be used for algorithm
 agility.
 
 Each entry in a DigestSet MUST be an immutable reference to an artifact. It is
@@ -34,6 +64,9 @@ further guidance.
 Standard cryptographic hash algorithms using [the NIST names][] (converting to
 lowercase and replacing `-` with `_`) as keys and lowercase hex-encoded values,
 for cases when the method of serialization is obvious or well known.
+
+In CBOR, the algorithm MAY be specified with an integer, as assigned by [IANA.named-information].
+Note the IANA registry does not have numeric assignments for all the above supported algorithms.
 
 #### `dirHash`
 
@@ -202,3 +235,4 @@ flexibility for the user's various use cases.
 [so-commit]: https://stackoverflow.com/a/37438460
 [so-tree]: https://stackoverflow.com/a/35902553
 [the NIST names]: https://csrc.nist.gov/projects/hash-functions
+[IANA.named-information]: https://www.iana.org/assignments/named-information/named-information.xhtml

--- a/spec/v1/envelope.md
+++ b/spec/v1/envelope.md
@@ -1,15 +1,16 @@
 # Envelope layer specification
 
-Version: [DSSE v1.0]
+The Envelope is the outermost layer of the attestation, handling authentication and serialization.
 
-The Envelope is the outermost layer of the attestation, handling
-authentication and serialization.
+A signing envelope may either be [DSSE v1.0] for JSON encoding or [RFC9052] for CBOR encoding.
 
-## Schema
+## Version [DSSE v1.0]
+
+### Schema
 
 The format and protocol are defined per [DSSE v1.0].
 
-## Fields
+### Fields
 
 The in-toto Attestation Framework has the following requirements for the
 standard DSSE fields.
@@ -19,7 +20,7 @@ standard DSSE fields.
     specifying its schema.
 -   `payload` MUST be a base64-encoded JSON [Statement].
 
-## File naming convention
+### File naming convention
 
 If stored in a dedicated file by itself, and not as part of a [Bundle], an
 Envelope SHOULD use the suffix `.json`.
@@ -35,7 +36,7 @@ Envelope SHOULD use the suffix `.json`.
     SHOULD include the truncated [KEYID] of the public key `<keyid[0:8]>` of
     the signing functionary: `<step/env-name>.<keyid[0:8]>.json`.
 
-## Storage convention
+### Storage convention
 
 The media type `application/vnd.in-toto.<predicate>+dsse` SHOULD
 be used to denote an individual attestation in arbitrary storage systems.
@@ -49,13 +50,33 @@ be used to denote an individual attestation in arbitrary storage systems.
 -   To obtain predicate information that is authenticated, consumers MUST
     parse the Envelope's `payload`, and verify it against its `signatures`.
 
-### Examples
+#### Examples
 
 Example media types for single DSSE-signed attestation predicates include:
 
 -   SLSA Provenance: `application/vnd.in-toto.provenance+dsse`
 -   SPDX: `application/vnd.in-toto.spdx+dsse`
 -   VSA: `application/vnd.in-toto.vsa+dsse`
+
+## Version [RFC9052]
+
+### Schema
+
+The format is defined to be the single signer envelope `COSE_Sign1` from [RFC9052].
+
+### File naming convention
+
+COSE objects do not have a standard file extension.
+If stored in a dedicated file by itself, and not as part of a [Bundle], an Envelope SHOULD use the suffix `.intoto.cose`.
+
+### Headers
+
+The in-toto Attestation Framework has the following requirements for the standard COSE headers.
+
+-   content type (label 3) MUST be set to `"application/vnd.in-toto+cbor`, which indicates that the Envelop contains a CBOR object with a `_type` field specifying its schema.
+
+No other headers are required.
+The envelope's payload array entry MUST be a CBOR-encoded [Statement].
 
 [Bundle]: bundle.md
 [DSSE v1.0]: https://github.com/secure-systems-lab/dsse/blob/v1.0.0/envelope.md
@@ -64,3 +85,4 @@ Example media types for single DSSE-signed attestation predicates include:
 [in-toto-verify]: https://github.com/in-toto/in-toto#verification
 [functionaries]: https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.md#212-functionaries
 [predicate specification filename]: ../predicates
+[RFC9052]: https://www.rfc-editor.org/rfc/rfc9052.html

--- a/spec/v1/field_types.md
+++ b/spec/v1/field_types.md
@@ -55,8 +55,15 @@ A point in time.
 
 **Format:**
 
+```cddl
+Timestamp = JC<text, text / tdate>
+```
+
 A timestamp is represented as a _string_ and MUST be in [RFC 3339][] format
 in the UTC timezone ("Z").
+
+In CBOR, a timestamp SHOULD be use the 0 tag to indicate the formatting, see [Section 3.4.1 of RFC8949].
+Note that tag 0 further refines RFC3339 to have a required `"T"` between date and time, following [Section 3.3 of RFC4287].
 
 **Example:**
 
@@ -71,3 +78,5 @@ in the UTC timezone ("Z").
 [SPDX Download Location]: https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field
 [Timestamp]: #timestamp
 [TypeURI]: #typeuri
+[Section 3.4.1 of RFC8949]: https://www.rfc-editor.org/rfc/rfc8949.html#name-standard-date-time-string
+[Section 3.3 of RFC4287]: https://www.rfc-editor.org/rfc/rfc4287#section-3.3

--- a/spec/v1/predicate.md
+++ b/spec/v1/predicate.md
@@ -3,19 +3,23 @@
 The Predicate is the innermost layer of the attestation, containing arbitrary
 metadata about the [Statement]'s `subject`.
 
-## Schema
+## Data description
 
-```jsonc
-"predicateType": "<URI>",
-"predicate": {
-    // arbitrary object
-}
+```cddl
+predicate-group = (
+  predicateType-label => uri-type,
+  ? predicate-label => object
+)
+
+predicateType-label = JC<"predicateType", 2>
+predicate-label     = JC<"predicate",     3>
+object = JC<{ * text => any }, { * any => any }>
 ```
 
 ## Fields
 
 A predicate has a required `predicateType` ([TypeURI]) identifying what the
-predicate means, plus an optional `predicate` [JSON] object containing
+predicate means, plus an optional `predicate` [JSON] object or CBOR map containing
 additional, type-dependent parameters.
 
 Users are expected to choose an [existing predicate type] that

--- a/spec/v1/resource_descriptor.md
+++ b/spec/v1/resource_descriptor.md
@@ -3,22 +3,45 @@
 A size-efficient description of any software artifact or resource (mutable
 or immutable).
 
-## Schema
+## Data description
 
-```json
-{
-  "name": "<NAME>",
-  "uri": "<RESOURCE URI>",
-  "digest": { "<ALGORITHM>": "<HEX VALUE>", ... },
-  "content": "<BASE64 VALUE>", // converted from bytes for JSON 
-  "downloadLocation": "<RESOURCE URI>",
-  "mediaType": "<MIME TYPE>",
-  "annotations": {
-    "<FIELD_1>": /* value */,
-    "<FIELD_2>": /* value */,
-    ...
-  }
+```cddl
+ResourceDescriptor = {
+  ? name-label => text,
+  at-least-one-of-uri-digest-content,
+  ? download-location-label => uri-type,
+  ? media-type-label => media-type,
+  ? annotations-label => annotations-map
 }
+
+at-least-one-of-uri-digest-content = (
+  uri-label => uri-type,
+  ? digest-label => DigestSet,
+  ? content-label => content
+) // (
+  ? uri-label => uri-type,
+  digest-label => DigestSet,
+  ? content-label => content
+) // (
+  ? uri-label => uri-type,
+  ? digest-label => DigestSet,
+  content-label => content
+)
+
+content = JC<text, bytes>
+
+name-label              = JC<"name",              0>
+uri-label               = JC<"uri",               1>
+digest-label            = JC<"digest",            2>
+content-label           = JC<"content",           3>
+download-location-label = JC<"download-location", 4>
+media-type-label        = JC<"mediaType",         5>
+annotations-label       = JC<"annotations",       6>
+
+media-type = text
+
+annotations-map = { * annotation-type => any }
+annotation-label = JC<text, text / int>
 ```
 
 ## Fields
@@ -95,6 +118,11 @@ specified here.
 > The producer and consumer SHOULD agree on the semantics, and acceptable
 > fields and values in the `annotations` map. Producers SHOULD follow the
 > same naming conventions for annotation fields as for [extension fields].
+>
+> In CBOR, the map key MAY be an integer for a more concise representation.
+> Negative integers may be used for enumerations agreed upon between producer
+> and consumer. Non-negative integers are reserved for in-toto specifications
+> to standardize.
 
 ## Semantics
 
@@ -137,9 +165,9 @@ Pointer to a git repo (with annotations):
 ```
 
 Pointer to another in-toto attestation:
-  
+
 ```jsonc
- { 
+ {
    "name": "gcc_9.3.0-1ubuntu2_amd64.intoto.json",
    "digest": { "sha256": "abcdabcde..." },
    "downloadLocation": "http://example.com/rebuilderd-instance/gcc_9.3.0-1ubuntu2_amd64.intoto.json",
@@ -148,7 +176,7 @@ Pointer to another in-toto attestation:
 ```
 
 Pointer to build service:
-
+o
 ```jsonc
 {
   "uri": "https://cloudbuild.googleapis.com/GoogleHostedWorker@v1"

--- a/spec/v1/statement.md
+++ b/spec/v1/statement.md
@@ -4,22 +4,29 @@ The Statement is the middle layer of the attestation, binding it to a
 particular subject and unambiguously identifying the types of the
 [Predicate].
 
-## Schema
+## Data description
 
-```jsonc
+The following CDDL describes both the JSON and CBOR encoding of an in-toto Statement.
+
+```cddl
+statement =
 {
-  "_type": "https://in-toto.io/Statement/v1",
-  "subject": [
-    {
-      "name": "<NAME>",
-      "digest": {"<ALGORITHM>": "<HEX_VALUE>"}
-    },
-    ...
-  ],
-  "predicateType": "<URI>",
-  "predicate": { ... }
+  _type-label => "https://in-toto.io/Statement/v1",
+  subject-label => [ + ResourceDescriptor ],
+  predicate-group
 }
+
+JC<J,C> = J .feature "json" / C .feature "cbor"
+
+_type-label         = JC<"_type",         0>
+subject-label       = JC<"subject",       1>
+
+uri-type        = JC<uri-text, uri-type-choice>
+uri-type-choice = uri-text / uri
+uri-text        = text
 ```
+
+The format of the `uri-type` SHOULD be a valid URI according to [RFC3986].
 
 ## Fields
 
@@ -55,15 +62,9 @@ Additional [parsing rules] apply.
 > content type. If this matters to you, please comment on
 > [GitHub Issue #28](https://github.com/in-toto/attestation/issues/28)
 
-`predicateType` _string ([TypeURI]), required_
+`predicate-group`
 
-> URI identifying the type of the [Predicate].
-
-`predicate` _object, optional_
-
-> Additional parameters of the [Predicate]. Unset is treated the same as
-> set-but-empty. MAY be omitted if `predicateType` fully describes the
-> predicate.
+See [Predicate].
 
 [ResourceDescriptor]: resource_descriptor.md
 [JSON]: https://www.json.org/json-en.html
@@ -71,3 +72,4 @@ Additional [parsing rules] apply.
 [SLSA Provenance]: https://slsa.dev/provenance
 [TypeURI]: field_types.md#TypeURI
 [parsing rules]: README.md#parsing-rules
+[RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986


### PR DESCRIPTION
As a means to improve the conciseness of in-toto, we can dually express objects in both JSON and CBOR using a standard data definition language called CDDL. This is complementary to https://github.com/in-toto/ITE/pull/60