### PR TITLE
Support validation of Cosign OCI statements with type https://in-toto.io/Statement/v0.1

### DIFF
--- a/go/v1/statement.go
+++ b/go/v1/statement.go
@@ -4,9 +4,13 @@ Wrapper APIs for in-toto attestation Statement layer protos.
 
 package v1
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
-const StatementTypeUri = "https://in-toto.io/Statement/v1"
+const StatementTypeUriPrefix = "https://in-toto.io/Statement/"
+const StatementTypeUri = StatementTypeUriPrefix + "v1"
 
 var (
 	ErrInvalidStatementType  = errors.New("wrong statement type")
@@ -17,7 +21,7 @@ var (
 )
 
 func (s *Statement) Validate() error {
-	if s.GetType() != StatementTypeUri {
+	if !strings.HasPrefix(s.GetType(), StatementTypeUriPrefix) {
 		return ErrInvalidStatementType
 	}
 

--- a/go/v1/statement_test.go
+++ b/go/v1/statement_test.go
@@ -52,7 +52,7 @@ func TestJsonUnmarshalStatement(t *testing.T) {
 }
 
 func TestBadStatementType(t *testing.T) {
-	var badStType = `{"_type":"https://in-toto.io/Statement/v0","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
+	var badStType = `{"_type":"https://not-in-toto.io/Statement/v0","subject":[{"name":"theSub","digest":{"alg1":"abc123"}}],"predicateType":"thePredicate","predicate":{"keyObj":{"subKey":"subVal"}}}`
 
 	got := &Statement{}
 	err := protojson.Unmarshal([]byte(badStType), got)


### PR DESCRIPTION
Support validation of Cosign OCI statements with type https://in-toto.io/Statement/v0.1

This change updates the `Validate` method to allow statements with type `https://in-toto.io/Statement/v0.1` in addition to `https://in-toto.io/Statement/v1`. This ensures compatibility with Cosign OCI signatures.

Fixes #461