### PR TITLE
Support validation of Cosign OCI statements with type https://in-toto.io/Statement/v0.1

### DIFF
--- a/go/v1/statement.go
+++ b/go/v1/statement.go
@@ -4,9 +4,13 @@ Wrapper APIs for in-toto attestation Statement layer protos.
 
 package v1
 
-import "errors"
+import (
+	"errors"
+)
 
-const StatementTypeUri = "https://in-toto.io/Statement/v1"
+const statementTypeUriPrefix = "https://in-toto.io/Statement/"
+const statementTypeUriLegacy = statementTypeUriPrefix + "v0.1"
+const StatementTypeUri = statementTypeUriPrefix + "v1"
 
 var (
 	ErrInvalidStatementType  = errors.New("wrong statement type")
@@ -17,7 +21,7 @@ var (
 )
 
 func (s *Statement) Validate() error {
-	if s.GetType() != StatementTypeUri {
+	if !s.isValidType() {
 		return ErrInvalidStatementType
 	}
 
@@ -47,4 +51,8 @@ func (s *Statement) Validate() error {
 	}
 
 	return nil
+}
+
+func (s *Statement) isValidType() bool {
+	return s.GetType() == StatementTypeUri || s.GetType() == statementTypeUriLegacy
 }


### PR DESCRIPTION
Support validation of Cosign OCI statements with type https://in-toto.io/Statement/v0.1

This change updates the  method to allow statements with type v0.1 in addition to v1. This ensures compatibility with Cosign OCI signatures.

Fixes #461