### PR TITLE
Add Trishank as attestation maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,4 +10,4 @@
 
 ## Emeritus
 
-*  [@joshuagl](https://github.com/joshuagl)
+-   [@joshuagl](https://github.com/joshuagl)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,13 @@
 # Maintainers
 
-| Name                       | GitHub          |
-|----------------------------|-----------------|
-| Marcela Melara (Intel)     | [@marcelamelara](https://github.com/marcelamelara) |
-| Mikhail Swift (TestifySec) | [@mikhailswift](https://github.com/mikhailswift) |
-| Parth Patel (Kusari)       | [@pxp928](https://github.com/pxp928) |
-| Tom Hennen (Google)        | [@TomHennen](https://github.com/TomHennen) |
+| Name                                 | GitHub          |
+|--------------------------------------|-----------------|
+| Marcela Melara (Intel)               | [@marcelamelara](https://github.com/marcelamelara) |
+| Mikhail Swift (TestifySec)           | [@mikhailswift](https://github.com/mikhailswift) |
+| Parth Patel (Kusari)                 | [@pxp928](https://github.com/pxp928) |
+| Tom Hennen (Google)                  | [@TomHennen](https://github.com/TomHennen) |
+| Trishank Karthik Kuppusamy (Datadog) | [@trishankatdatadog](https://github.com/trishankatdatadog) |
+
+## Emeritus
+
+*  [@joshuagl](https://github.com/joshuagl)


### PR DESCRIPTION
We've been seeing an increased activity again, and as we work towards in-toto v2, it would be really helpful to have five maintainers again to increase our review throughput. I propose adding @trishankatdatadog (who has agreed) as our fifth maintainer. Trishank is co-author of the original in-toto spec and a current ITSC member.

This PR also recognizes Joshua Lock as an Emeritus maintainer.