### PR TITLE
Add predicate type to the allowed media types for the envelope's payload type

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -30,7 +30,7 @@ Steps:
 -   Intermediate state: `envelope.payloadType`, `envelope.payload`,
     `attesterNames`
 -   Statement layer:
-    -   Reject if `envelope.payloadType` != `application/vnd.in-toto+json`
+    -   Reject if (`envelope.payloadType` != `application/vnd.in-toto+json` OR `envelope.payloadType` does not match `application/vnd.in-toto.<predicate file name>+json`)
     -   `statement` := decode `envelope.payload` as a JSON-encoded
         [Statement]; reject if decoding fails
     -   Reject if `statement.type` != `https://in-toto.io/Statement/v1`

--- a/spec/v1/bundle.md
+++ b/spec/v1/bundle.md
@@ -48,12 +48,12 @@ two attestations, one with subject `abcd` and one with subject `1234`.
 The media type `application/vnd.in-toto.bundle` SHOULD be used to denote
 a Bundle in arbitrary storage systems.
 
--   The media type for a Bundles does not indicate an encoding since Bundles
+-   The media type for a Bundle does not indicate an encoding since Bundles
     MUST be encoded as JSON lines, and the encoding of each attestation
     within the Bundle SHOULD be indicated at the [Envelope] layer.
 -   The predicate type of individual attestations within the stored Bundle
-    SHOULD NOT be indicated in the media type for the Bundle, as this
-    information is not authenticated at the Bundle layer.
+    SHOULD NOT be indicated in the media type for the Bundle, as a bundle may
+    contain attestations with different predicate types.
 -   To obtain predicate information that is authenticated, consumers MUST
     download and parse each line in a Bundle separately.
 
@@ -73,7 +73,7 @@ places _both_ of these signed attestations in a new file named
 `fooly.apk.intoto.jsonl`.
 
 ```jsonl
-{ "payloadType": "application/vnd.in-toto+json", "payload": "a...", "signatures": [w...] }
+{ "payloadType": "application/vnd.in-toto.provenance+json", "payload": "a...", "signatures": [w...] }
 { "payloadType": "application/vnd.in-toto+json", "payload": "b...", "signatures": [w...] }
 ```
 
@@ -89,7 +89,7 @@ vulnerabilities.
 The TestResult is then appended to the contents of `fooly.apk.intoto.jsonl`
 
 ```jsonl
-{ "payloadType": "application/vnd.in-toto+json", "payload": "a...", "signatures": [w...] }
+{ "payloadType": "application/vnd.in-toto.provenance+json", "payload": "a...", "signatures": [w...] }
 { "payloadType": "application/vnd.in-toto+json", "payload": "b...", "signatures": [w...] }
 { "payloadType": "application/vnd.novulz+cbor", "payload": "c...", "signatures": [x...] }
 ```
@@ -102,10 +102,10 @@ with hash `aaa...` using an in-toto Statement with
 and appending that to the contents of `fooly.apk.intoto.jsonl`.
 
 ```jsonl
-{ "payloadType": "application/vnd.in-toto+json", "payload": "a...", "signatures": [w...] }
+{ "payloadType": "application/vnd.in-toto.provenance+json", "payload": "a...", "signatures": [w...] }
 { "payloadType": "application/vnd.in-toto+json", "payload": "b...", "signatures": [w...] }
 { "payloadType": "application/vnd.novulz+cbor", "payload": "c...", "signatures": [x...] }
-{ "payloadType": "application/vnd.in-toto+json", "payload": "d...", "signatures": [y...] }
+{ "payloadType": "application/vnd.in-toto.spdx+json", "payload": "d...", "signatures": [y...] }
 ```
 
 ### Deployment

--- a/spec/v1/envelope.md
+++ b/spec/v1/envelope.md
@@ -14,9 +14,19 @@ The format and protocol are defined per [DSSE v1.0].
 The in-toto Attestation Framework has the following requirements for the
 standard DSSE fields.
 
--   `payloadType` MUST be set to `application/vnd.in-toto+json`, which
-    indicates that the Envelope contains a JSON object with a `_type` field
-    specifying its schema.
+-   `payloadType` MUST be set to `application/vnd.in-toto.predicate+json` or to
+    `application/vnd.in-toto+json`. This indicates that the Envelope contains
+    a JSON object with a `_type` field specifying its schema. If the
+    predicate-specific media type is used, the following requirements apply:
+    -   `<predicate>` MUST match the [predicate specification filename] without
+        the file extension.
+    -   Consumers SHOULD NOT rely upon the media type for individual attestations
+        as faithful indicators of predicate type. Consumer SHOULD only rely on the
+        `predicateType` field in the [Statement] layer.
+    -   To obtain predicate information that is authenticated, consumers MUST
+        parse the Envelope's `payload`, and verify it against its `signatures`.
+    -   The predicate version is not specified in the media type; it is handled
+        in the [Statement] layer.
 -   `payload` MUST be a base64-encoded JSON [Statement].
 
 ## File naming convention


### PR DESCRIPTION
This PR adds the predicate type to the allowed values for the envelope's payload type. A typo is also fixed in `bundle.md`.

Predicate-specific media types are already recommended for individual attestations in storage systems -- see
https://github.com/in-toto/attestation/blob/df7135a090fae2ed449bd95341652a9a2905b8e8/spec/v1/envelope.md#storage-convention. This PR makes the equivalent change for the envelope's `payloadType`.

The motivation is to make it easier to consume attestations (e.g. when manually opening up a bundle, https://github.com/in-toto/attestation/issues/405), and it also makes the two uses of the media types more consistent. There may be some risk that a consumer uses the media type as evidence for a policy decision, but this is warned against in the documentation.

The current `payloadType` (`application/vnd.in-toto+json`) is left as an allowed value for backwards compatibility. 

This doesn't specify how to handle predicate-specific payload types for predicates that are not registered in this repo. These cases can continue to use `application/vnd.in-toto+json`, and this can be followed up on if needed.

