### PR TITLE
Fix: Rust codegen in CI and Linter errors

### DIFF
--- a/protos/Makefile
+++ b/protos/Makefile
@@ -13,6 +13,6 @@ java:
 
 # Creates the Rust libs in the rust/ directory.
 rust:
-	cd rust && cargo build
+	cd ../rust && cargo build
 
 .PHONY: go python java rust

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,7 +19,7 @@ The following diagram visualises the relationships between the envelope, stateme
 
 <img src="../images/envelope_relationships.png" alt="Relationships between the envelope, statement and predicate layers" width="600">
 
-The source of this diagram can be found [here](../images/envelope_relationships.excalidraw).
+For future edits, we provide the [source](../images/envelope_relationships.excalidraw) of this diagram.
 
 The [validation model] provides pseudocode showing how these layers fit
 together. See the [documentation] for more background and examples.

--- a/spec/predicates/README.md
+++ b/spec/predicates/README.md
@@ -14,6 +14,7 @@ our [vetting process], and may be of general interest:
 
 -   [SLSA Provenance]: Describes how an artifact or set of artifacts was
     produced.
+<!-- markdownlint-disable-next-line MD059 -->
 -   [Link]: For migration from [in-toto 0.9].
 -   [SCAI Report]: Evidence-based assertions about software artifact and
     supply chain attributes or behavior.

--- a/spec/v0.1.0/README.md
+++ b/spec/v0.1.0/README.md
@@ -173,6 +173,7 @@ new one if no existing one satisfies. Predicate types are not registered.
 The following popular predicate types may be of general interest:
 
 -   [SLSA Provenance]: To describe the origins of a software artifact.
+<!-- markdownlint-disable-next-line MD059 -->
 -   [Link]: For migration from [in-toto 0.9].
 -   [SPDX]: A Software Package Data Exchange document.
 


### PR DESCRIPTION
This PR fixes a CI error where the Rust code generation fails due to a wrong path in the Makefile. It also fixes three link-related linter errors.