### PR TITLE
Bump Go version in CI tests

### DIFF
--- a/.github/workflows/run-go-tests.yml
+++ b/.github/workflows/run-go-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       - name: Setup Env


### PR DESCRIPTION
This PR bumps the go version used in the CI tests to 1.23.x, matching the version used to build the Go bindings.