### PR TITLE
Add eval-result predicate (AI/ML evaluation results)

### DIFF
--- a/spec/predicates/README.md
+++ b/spec/predicates/README.md
@@ -15,6 +15,8 @@ our [vetting process], and may be of general interest:
 -   [CycloneDX]: CycloneDX BOM for software artifacts.
 <!-- markdownlint-disable-next-line MD059 -->
 -   [Link]: For migration from [in-toto 0.9].
+-   [ML Eval Result]: Signed, offline-verifiable machine-learning evaluation
+    results as threshold claims, with private-model commitments.
 -   [Reference]: References documents that are relevant to some resource.
 -   [Release]: Details an artifact that is part of a given release version.
 -   [Runtime Traces]: Captures runtime traces of software supply chain
@@ -34,6 +36,7 @@ our [vetting process], and may be of general interest:
 
 [CycloneDX]: https://cyclonedx.org/
 [Link]: link.md
+[ML Eval Result]: eval-result.md
 [New Predicate Guidelines]: ../../docs/new_predicate_guidelines.md
 [Release]: release.md
 [Runtime Traces]: runtime-trace.md

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -1,0 +1,156 @@
+# Predicate type: ML eval-result
+
+Type URI: https://in-toto.io/attestation/eval-result/v0.1
+
+Version: v0.1
+
+Authors: Konrad Gruszka (@b7n0de, ORCID 0009-0006-8947-6065)
+
+## Purpose
+
+Attest the result of a machine-learning **evaluation** in a way a generic in-toto verifier can consume,
+while keeping the evaluated model and dataset **private**. An ML eval has three properties the generic
+[`test-result`](test-result.md) predicate does not model: a **metric threshold** with a pass/fail
+against it, the need to withhold the model/dataset identity, and an optional binding to an external
+signed receipt (and, later, an external time anchor for pre-registration).
+
+This predicate authenticates a *claim*: *who signed these exact eval bytes, and that nothing changed
+since*. It does **not** assert the semantic truth, fairness, safety, or generalization of the result;
+those remain human judgements (see [Non-claims](#non-claims)).
+
+## Use Cases
+
+-   **Private-model eval**: publish "model M passed safety suite S at `refusal_rate >= 0.98`" without
+    revealing M or the dataset, via salted commitments; a relying party verifies the signed claim offline.
+-   **Release gating**: bind a release artifact (image/wheel/service digest) to a passing eval, "deploy
+    only if the eval passed", as the ML attach point for a policy/SLSA decision.
+-   **Pre-registration**: commit to the threshold and the dataset/model *before* the run, and later prove
+    the commitment predated the result (strengthened by an external time anchor).
+
+## Prerequisites
+
+in-toto attestation [spec v1](../v1/README.md). The evaluation is expressed as one or more
+threshold-based claims `{metric, comparator, threshold, passed}`. Identifiers that must stay private are
+carried as **salted commitments** (a hash over a secret salt ‖ identifier); the salt stays with the
+issuer and is never in the attestation.
+
+## Model
+
+An evaluation run produces a signed, tamper-evident receipt. This predicate is a projection of that
+receipt onto an in-toto Statement: the `subject` is what the attestation is *about* (the receipt itself,
+a public model artifact, or a gated release artifact), and the predicate carries the eval's facts. The
+detailed per-metric result lives here; a companion [SVR](svr.md)
+may summarize "a verifier confirmed this passed" as passing property strings.
+
+## Schema
+
+```jsonc
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [{ "name": "<optional>", "digest": { "<alg>": "<hex>" } }],
+  "predicateType": "https://in-toto.io/attestation/eval-result/v0.1",
+  "predicate": {
+    "verifier": { "id": "<TypeURI>" },
+    "evaluatedAt": "<RFC 3339>",
+    "suite": { "name": "<string>", "version": "<string>" },
+    "claims": [
+      { "metric": "<string>", "comparator": ">=|>|<=|<", "threshold": "<decimal string>", "passed": <bool> }
+    ],
+    "sampleSize": <int>,
+    "commitments": {
+      "model":   { "alg": "<string>", "value": "<hex>", "salted": true },
+      "dataset": { "alg": "<string>", "value": "<hex>", "salted": true }
+    },
+    "assuranceLevel": "self_attested|third_party|reproduced|enclave_attested",
+    "subjectProfile": "receipt|public-model|release-gate",
+    "preRegistration": { "alg": "sha256", "value": "<hex>" },   // OPTIONAL
+    "receipt": { "schema": "<string>", "merkleRootB64": "<base64>" },  // OPTIONAL
+    "harness": { "name": "<string>", "version": "<string>" },   // OPTIONAL
+    "anchors": [ /* external time anchors, OPTIONAL, see the anchors extension */ ]
+  }
+}
+```
+
+### Parsing Rules
+
+This predicate follows the in-toto attestation
+[spec v1 parsing rules](../v1/README.md#parsing-rules): consumers **match on the subject `digest`
+alone**; `subject[].name` is a hint and MAY be `"_"` or omitted; unknown predicate fields MUST be
+ignored (forward compatibility); and the
+[Monotonic Principle](../../docs/validation.md) applies: a verifier denies unless a valid attestation
+exists. Time fields are RFC 3339. `threshold` is a decimal **string**, never a JSON float, so a value
+is never altered by float round-tripping.
+
+### Fields
+
+`verifier.id` *(TypeURI, required)*: the party that emitted/verified the result.
+
+`evaluatedAt` *(Timestamp, required)*: when the evaluation ran.
+
+`suite` *(object, required)*: `{name, version}` of the eval suite.
+
+`claims` *(array, required)*: one or more `{metric, comparator, threshold, passed}`. `comparator` is one
+of `>=`, `>`, `<=`, `<`; `passed` is the pass of `metric comparator threshold`.
+
+`sampleSize` *(int, required)*: number of samples the result is over.
+
+`commitments` *(object, required)*: `model` and `dataset`, each `{alg, value, salted}`. When `salted` is
+`true` the `value` is a commitment (a hash over a secret salt ‖ identifier), **NOT** an artifact content
+digest; a generic verifier MUST NOT treat it as one. This is what lets the evaluated model/dataset stay
+private while the claim is still verifiable.
+
+`assuranceLevel` *(string, required)*: how much a pass is worth: `self_attested` (producer testimony),
+`third_party`, `reproduced`, or `enclave_attested`.
+
+`subjectProfile` *(string, required)*: which subject the attestation binds to: `receipt` (a binder over
+the receipt; reveals nothing), `public-model` (a disclosed model's real digest), or `release-gate` (a
+release artifact gated on the pass).
+
+`preRegistration` *(object, optional)*: `{alg, value}` over the eval protocol committed before the run.
+
+`receipt` *(object, optional)*: `{schema, merkleRootB64}` binding to the external signed receipt.
+
+`harness` *(object, optional)*: `{name, version}` of the eval harness.
+
+`anchors` *(array, optional)*: external time anchors (e.g. RFC 3161 TSA, OpenTimestamps) for the
+receipt or the pre-registration. Defined by a separate anchors extension.
+
+## Non-claims
+
+A verifier that accepts this attestation learns that the signed claim is authentic and unchanged. It
+does **not** learn that the metric is correct, that the eval was well designed, that the model is safe
+or fair, or that the score generalizes. Those are out of scope for this predicate.
+
+## Examples
+
+A private-model eval (subject is the receipt; the model stays secret):
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [{ "name": "eval-receipt", "digest": { "sha256": "…" } }],
+  "predicateType": "https://in-toto.io/attestation/eval-result/v0.1",
+  "predicate": {
+    "verifier": { "id": "https://example.com/verifier" },
+    "evaluatedAt": "2026-07-05T12:00:00Z",
+    "suite": { "name": "safety-refusals", "version": "1.2.0" },
+    "claims": [{ "metric": "refusal_rate", "comparator": ">=", "threshold": "0.98", "passed": true }],
+    "sampleSize": 500,
+    "commitments": {
+      "model":   { "alg": "sha256-salted-v1", "value": "…", "salted": true },
+      "dataset": { "alg": "sha256-salted-v1", "value": "…", "salted": true }
+    },
+    "assuranceLevel": "self_attested",
+    "subjectProfile": "receipt",
+    "receipt": { "schema": "proofbundle/v0.1", "merkleRootB64": "…" }
+  }
+}
+```
+
+A release-gate example (subject is the deployed artifact's real digest) is in the reference
+implementation's `examples/intoto/release-gate.statement.json`.
+
+## Changelog and Migrations
+
+-   v0.1: initial draft. Reference emitter/verifier: [proofbundle](https://github.com/b7n0de/proofbundle)
+    (`proofbundle intoto`). Discussion: in-toto/attestation#565.

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -131,11 +131,11 @@ or fair, or that the score generalizes. Those are out of scope for this predicat
 This predicate does not establish that the evaluation harness or grader is fit for purpose, or
 that it has any particular detection performance.
 
-The consequences of this non-claim are not symmetric. For a claim about what the subject achieves,
-a harness that under-detects understates the subject. For a claim about what the subject withholds
-or refuses, a harness that under-detects yields `passed: true` for a subject that did not withhold
-it, and this predicate carries that result no differently from any other. The use cases above and
-the example below are of the second kind.
+The consequences can be asymmetric. When detected positives are evidence of capability, missed
+positives can understate performance. When `passed: true` depends on the absence of detected
+failures, missed failures can instead yield a passing verdict even though the failures occurred.
+This attestation authenticates either verdict without establishing the harness's detection
+capability.
 
 ## Examples
 

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -65,7 +65,7 @@ may summarize "a verifier confirmed this passed" as passing property strings.
     "subjectProfile": "receipt|public-model|release-gate",
     "preRegistration": { "alg": "sha256", "value": "<hex>" },   // OPTIONAL
     "receipt": { "schema": "<string>", "merkleRootB64": "<base64>" },  // OPTIONAL
-    "harness": { "name": "<string>", "version": "<string>" },   // OPTIONAL
+    "harness": { "name": "<string>", "version": "<string>", "digest": { "sha256": "<hex>" } },  // OPTIONAL
     "anchors": [ /* external time anchors, OPTIONAL, see the anchors extension */ ]
   }
 }
@@ -110,7 +110,11 @@ release artifact gated on the pass).
 
 `receipt` *(object, optional)*: `{schema, merkleRootB64}` binding to the external signed receipt.
 
-`harness` *(object, optional)*: `{name, version}` of the eval harness.
+`harness` *(object, optional)*: the eval harness. `name` and `version` identify it. `digest` is an
+optional [DigestSet](../v1/digest_set.md) over the harness artifact, for consumers that need to bind
+the exact artifact that produced the result. A `harness` that carries only `name` and `version`
+remains conforming. `digest` binds identity only. It asserts nothing about the harness's detection
+performance.
 
 `anchors` *(array, optional)*: external time anchors (e.g. RFC 3161 TSA, OpenTimestamps) for the
 receipt or the pre-registration. Defined by a separate anchors extension.

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -81,6 +81,9 @@ ignored (forward compatibility); and the
 exists. Time fields are RFC 3339. `threshold` is a decimal **string**, never a JSON float, so a value
 is never altered by float round-tripping.
 
+Unless a field specifies otherwise, absence of an optional field means only that no claim is made
+for that field. Consumers MUST NOT infer or synthesize a default value from absence.
+
 ### Fields
 
 `verifier.id` *(TypeURI, required)*: the party that emitted/verified the result.

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -128,6 +128,9 @@ A verifier that accepts this attestation learns that the signed claim is authent
 does **not** learn that the metric is correct, that the eval was well designed, that the model is safe
 or fair, or that the score generalizes. Those are out of scope for this predicate.
 
+This predicate does not establish that the evaluation harness or grader is fit for purpose, or
+that it has any particular detection performance.
+
 ## Examples
 
 A private-model eval (subject is the receipt; the model stays secret):

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -92,7 +92,9 @@ for that field. Consumers MUST NOT infer or synthesize a default value from abse
 `suite` *(object, required)*: `{name, version}` of the eval suite.
 
 `claims` *(array, required)*: one or more `{metric, comparator, threshold, passed}`. `comparator` is one
-of `>=`, `>`, `<=`, `<`; `passed` is the pass of `metric comparator threshold`.
+of `>=`, `>`, `<=`, `<`. `passed` is the producer's signed threshold verdict for the stated metric,
+comparator and threshold. Unless an exact observed value is disclosed by a separate profile, a generic
+consumer can authenticate the verdict but cannot recompute it from the predicate alone.
 
 `sampleSize` *(int, required)*: number of samples the result is over.
 

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -65,8 +65,7 @@ may summarize "a verifier confirmed this passed" as passing property strings.
     "subjectProfile": "receipt|public-model|release-gate",
     "preRegistration": { "alg": "sha256", "value": "<hex>" },   // OPTIONAL
     "receipt": { "schema": "<string>", "merkleRootB64": "<base64>" },  // OPTIONAL
-    "harness": { "name": "<string>", "version": "<string>", "digest": { "sha256": "<hex>" } },  // OPTIONAL
-    "anchors": [ /* external time anchors, OPTIONAL, see the anchors extension */ ]
+    "harness": { "name": "<string>", "version": "<string>", "digest": { "sha256": "<hex>" } }  // OPTIONAL
   }
 }
 ```
@@ -118,9 +117,6 @@ optional [DigestSet](../v1/digest_set.md) over the harness artifact, for consume
 the exact artifact that produced the result. A `harness` that carries only `name` and `version`
 remains conforming. `digest` binds identity only. It asserts nothing about the harness's detection
 performance.
-
-`anchors` *(array, optional)*: external time anchors (e.g. RFC 3161 TSA, OpenTimestamps) for the
-receipt or the pre-registration. Defined by a separate anchors extension.
 
 ## Non-claims
 

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -103,8 +103,10 @@ consumer can authenticate the verdict but cannot recompute it from the predicate
 digest; a generic verifier MUST NOT treat it as one. This is what lets the evaluated model/dataset stay
 private while the claim is still verifiable.
 
-`assuranceLevel` *(string, required)*: how much a pass is worth: `self_attested` (producer testimony),
-`third_party`, `reproduced`, or `enclave_attested`.
+`assuranceLevel` *(string, required)*: an issuer-declared assurance claim about how the result was
+produced: `self_attested` (producer testimony), `third_party`, `reproduced`, or `enclave_attested`. The
+value is the issuer's own declaration; this predicate does not corroborate it. External corroboration
+belongs in separately referenced evidence.
 
 `subjectProfile` *(string, required)*: which subject the attestation binds to: `receipt` (a binder over
 the receipt; reveals nothing), `public-model` (a disclosed model's real digest), or `release-gate` (a

--- a/spec/predicates/eval-result.md
+++ b/spec/predicates/eval-result.md
@@ -131,6 +131,12 @@ or fair, or that the score generalizes. Those are out of scope for this predicat
 This predicate does not establish that the evaluation harness or grader is fit for purpose, or
 that it has any particular detection performance.
 
+The consequences of this non-claim are not symmetric. For a claim about what the subject achieves,
+a harness that under-detects understates the subject. For a claim about what the subject withholds
+or refuses, a harness that under-detects yields `passed: true` for a subject that did not withhold
+it, and this predicate carries that result no differently from any other. The use cases above and
+the example below are of the second kind.
+
 ## Examples
 
 A private-model eval (subject is the receipt; the model stays secret):


### PR DESCRIPTION
Closes the ask in #565 (proposal discussion since 2026-07-03), as offered there on 2026-07-18.

### What this adds

`eval-result.md` per the ITE-9 template plus one line in the predicate directory: a predicate
for signed, offline-verifiable AI/ML evaluation results. A claim is a machine-checkable
`metric <comparator> threshold` verdict over N samples, with salted model/dataset commitments,
an optional per-sample RFC 6962 Merkle root, an optional pre-registration binding, and an
explicit `assuranceLevel` (self_attested | third_party | reproduced | enclave_attested).
Protobuf bindings follow as a separate PR, per the SVR precedent (#470 -> #519 -> #537).

### Changes since the initial submission

Additive, all in the one file, all out of the discussion in #565 and in this thread: `harness`
gained an optional `digest` binding the exact harness artifact; a general rule that absence of
an optional field means no claim is made and consumers MUST NOT synthesize a default from it;
an explicit non-claim that this predicate does not establish that the harness or grader is fit
for purpose; `passed` stated as a signed threshold verdict; `assuranceLevel` marked as
issuer-declared; `anchors[]` removed (887708f); and an informative note on the asymmetric
consequences of the harness non-claim. The diff has been stable since `35c83da`.

### Why a new predicate

Discussed in #565: test-result carries PASSED|WARNED|FAILED plus test names but no
metric/threshold/dataset digests, commitments or per-sample structure; SVR's property list
would need a schema re-invented inside a free-form field. eval-result keeps the claim shape
fixed so a policy engine can evaluate "did model M clear threshold X on benchmark Y" without
parsing prose out of a system card.

### Scope, pinned

Metric evidence only. Not an agent-decision attestation, not an action authorization, no
decision fields will be added (boundary suggested by @clementineCU in #565 and kept). A
separate decision-oriented predicate MAY reference signed eval-result statements by digest.
The attestation proves who signed which claim and that it verifies offline, not that the
metric is true, the benchmark well designed, or the model safe.

### Maturity evidence

| Item | State |
|---|---|
| Reference implementation | proofbundle (MIT), current release 4.0.0 on PyPI; emits DSSE-signed statements + RFC 6962 proofs |
| Example statements | three modes, versioned: public-model, private-model (receipt), release-gate |
| Real-world statement | 1181-sample eval posted in #565, verifies offline (signature, canonical bytes, subject binder) |
| Second implementation | MarkovianProtocol/audit-anchor reproduces canonicalization and content roots byte-for-byte |
| Graduated cross-impl case | `decision-crossimpl-schema-conformant` in the conformance corpus: an independently implemented decision receipt binds an eval-result evidence statement by digest, both implementations agree byte-for-byte on canonical bytes and content roots (decision root `97e1d74b…`), recorded schema-conformant against the published schema, vendored as pure data with permanent attribution |
| Composition in the wild | a third participant in #565 (2026-07-19) builds on exactly this composition pattern, referencing eval-result statements by digest from a broader evidence profile instead of widening the predicate |

### Two design points flagged for review

1. In the private-model mode the subject is the eval receipt (a metadata object, permitted by
   the DigestSet definition as an immutable reference). Its sha256 is a documented binder over
   commitments, Merkle root and timestamp, marked by an explicit `subjectDigestNote`. As
   offered in #565: the receipt-as-subject digest-set question stays open for review here,
   and we are happy to switch to a custom digest-set key before merge if you prefer.
2. The statements declare one top-level extension field, `contentRootAlg`, naming the
   canonicalization the content root is computed over; ignorable by generic consumers per the
   spec's parsing rules.

> [!NOTE]
> `anchors[]` (external time anchors over a canonical root, drafted with @MarkovianProtocol in
> #565) is deliberately NOT part of this PR. The thread consensus is that it is not
> eval-specific and belongs as a shared optional field; we would bring it as its own
> discussion if there is interest.

DCO signed. markdownlint last ran clean locally at `f2c26cb` (pinned 0.49.1, rc=0); the
repository lint workflow is still awaiting maintainer approval, so it has not run here. Happy
to adjust naming, casing or file placement to match directory conventions.