### PR TITLE
go/v1: accept SHA-256 git object digests

### DIFF
--- a/go/v1/resource_descriptor.go
+++ b/go/v1/resource_descriptor.go
@@ -8,6 +8,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
+	"strconv"
+	"strings"
 )
 
 var (
@@ -85,14 +88,43 @@ func (algo HashAlgorithm) String() string {
 	return string(algo)
 }
 
-// Indicates if a given fixed-size hash algorithm is supported by default and returns the algorithm's
-// digest size in bytes, if supported. We assume gitCommit and dirHash are aliases for sha1 and sha256, respectively.
+// digestLengths returns every digest size in bytes that an algorithm accepts.
+//
+// Most algorithms have exactly one. The git object algorithms have two: git
+// names objects with either a SHA-1 or a SHA-256 hash, and digest_set.md
+// accepts both, telling them apart by length.
+func (algo HashAlgorithm) digestLengths() []int {
+	switch algo {
+	case AlgorithmGitBlob, AlgorithmGitCommit, AlgorithmGitTag, AlgorithmGitTree:
+		return []int{20, 32}
+	}
+
+	if size := algo.HexLength(); size > 0 {
+		return []int{size}
+	}
+
+	return nil
+}
+
+// Indicates if a given hash algorithm is supported by default and returns the
+// digest sizes in bytes that it accepts, if supported.
 //
 // SHA digest sizes from https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
 // MD5 digest size from https://www.rfc-editor.org/rfc/rfc1321.html#section-1
-func isSupportedFixedSizeAlgorithm(algString string) (bool, int) {
-	algo := HashAlgorithm(algString)
-	return algo.HexLength() > 0, algo.HexLength()
+func isSupportedAlgorithm(algString string) (bool, []int) {
+	sizes := HashAlgorithm(algString).digestLengths()
+	return len(sizes) > 0, sizes
+}
+
+// formatSizes renders the accepted digest sizes for an error message, e.g.
+// "20" or "20 or 32".
+func formatSizes(sizes []int) string {
+	strs := make([]string, 0, len(sizes))
+	for _, size := range sizes {
+		strs = append(strs, strconv.Itoa(size))
+	}
+
+	return strings.Join(strs, " or ")
 }
 
 func (d *ResourceDescriptor) Validate() error {
@@ -107,7 +139,7 @@ func (d *ResourceDescriptor) Validate() error {
 			// Per https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
 			// check encoding and length for supported algorithms;
 			// use of custom, unsupported algorithms is allowed and does not not generate validation errors.
-			supported, size := isSupportedFixedSizeAlgorithm(alg)
+			supported, sizes := isSupportedAlgorithm(alg)
 			if supported {
 				// the in-toto spec expects a hex-encoded string in DigestSets for supported algorithms
 				hashBytes, err := hex.DecodeString(digest)
@@ -117,8 +149,8 @@ func (d *ResourceDescriptor) Validate() error {
 				}
 
 				// check the length of the digest
-				if len(hashBytes) != size {
-					return fmt.Errorf("%w: got %d bytes, want %d bytes (%s: %s)", ErrIncorrectDigestLength, len(hashBytes), size, alg, digest)
+				if !slices.Contains(sizes, len(hashBytes)) {
+					return fmt.Errorf("%w: got %d bytes, want %s bytes (%s: %s)", ErrIncorrectDigestLength, len(hashBytes), formatSizes(sizes), alg, digest)
 				}
 			}
 		}

--- a/go/v1/resource_descriptor_test.go
+++ b/go/v1/resource_descriptor_test.go
@@ -101,3 +101,39 @@ func TestBadResourceDescriptorDigestLength(t *testing.T) {
 	err = got.Validate()
 	assert.ErrorIs(t, err, ErrIncorrectDigestLength, "did not get expected error when validating ResourceDescriptor with incorrect digest length")
 }
+
+const gitCommitSha1Rd = `{"name":"artifact","digest":{"gitCommit":"a1234567b1234567c1234567d1234567e1234567"}}`
+
+const gitCommitSha256Rd = `{"name":"artifact","digest":{"gitCommit":"a1234567b1234567c1234567d1234567e1234567f1234567a1234567b1234567"}}`
+
+const badGitCommitLengthRd = `{"name":"artifact","digest":{"gitCommit":"abc123"}}`
+
+func TestGitCommitDigestSha1(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(gitCommitSha1Rd), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.NoError(t, err, "Error during validation of RD with SHA-1 gitCommit digest")
+}
+
+func TestGitCommitDigestSha256(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(gitCommitSha256Rd), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.NoError(t, err, "Error during validation of RD with SHA-256 gitCommit digest")
+}
+
+func TestBadGitCommitDigestLength(t *testing.T) {
+	got := &ResourceDescriptor{}
+	err := protojson.Unmarshal([]byte(badGitCommitLengthRd), got)
+
+	assert.NoError(t, err, "Error during JSON unmarshalling")
+
+	err = got.Validate()
+	assert.ErrorIs(t, err, ErrIncorrectDigestLength, "did not get expected error when validating ResourceDescriptor with incorrect gitCommit digest length")
+}


### PR DESCRIPTION
digest_set.md says gitCommit, gitTree, gitBlob and gitTag hold the lowercase hex of the object's SHA-1 (40 char) or SHA-256 (64 char) hash. But HexLength() returns 20 bytes for all four git algorithms, so ResourceDescriptor.Validate rejects a valid SHA-256 git digest with ErrIncorrectDigestLength.

This tracks the accepted byte sizes per algorithm instead of a single length, and lets the git object algorithms accept 20 or 32 bytes. Existing SHA-1 digests keep working, and a wrong-length git digest is still rejected. Added a test case covering a 64-char gitCommit digest.

Refs #184.