### PR TITLE
docs: point the vetting process at a meeting a contributor can find

### DIFF
--- a/docs/new_predicate_guidelines.md
+++ b/docs/new_predicate_guidelines.md
@@ -59,7 +59,7 @@ Our vetting process is simple, and is based on the process specified in [ITE-9].
 2.  The in-toto Attestation Framework maintainers will review the PR.
     Subproject activity is reported at the monthly [community meeting], the
     open forum for raising a proposal or asking about the status of one.
-    Agendas and minutes are kept with the [meeting notes].
+    Agendas and minutes are kept with the [meeting notes], now on [HackMD].
 3.  If accepted, the new predicate type will be included in our directory.
 4.  Finally, if the new [predicateType] URI is defined under the
     https://in-toto.io/attestation namespace, submit a PR to add the following
@@ -71,6 +71,7 @@ Our vetting process is simple, and is based on the process specified in [ITE-9].
 [Predicates]: ../spec/v1/predicate.md
 [community meeting]: https://zoom-lfx.platform.linuxfoundation.org/meetings/intoto
 [meeting notes]: https://github.com/in-toto/community/tree/main/community-meetings
+[HackMD]: https://hackmd.io/Czv1Si4jQkieo_qByoMkPQ
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [URL redirects list]: https://github.com/in-toto/in-toto.io/blob/main/layouts/index.redirects
 [field types]: ../spec/v1/field_types.md

--- a/docs/new_predicate_guidelines.md
+++ b/docs/new_predicate_guidelines.md
@@ -56,8 +56,10 @@ Our vetting process is simple, and is based on the process specified in [ITE-9].
     -   Add the new predicate to the list of [existing predicates].
     -   To generate Go/Python/Java language bindings for the new predicate,
         include a [protobuf definition].
-2.  The in-toto Attestation Framework maintainers will review the PR at the
-    next maintainers meeting.
+2.  The in-toto Attestation Framework maintainers will review the PR.
+    Subproject activity is reported at the monthly [community meeting], the
+    open forum for raising a proposal or asking about the status of one.
+    Agendas and minutes are kept with the [meeting notes].
 3.  If accepted, the new predicate type will be included in our directory.
 4.  Finally, if the new [predicateType] URI is defined under the
     https://in-toto.io/attestation namespace, submit a PR to add the following
@@ -67,6 +69,8 @@ Our vetting process is simple, and is based on the process specified in [ITE-9].
 
 [ITE-9]: https://github.com/in-toto/ITE/tree/master/ITE/9#document-format
 [Predicates]: ../spec/v1/predicate.md
+[community meeting]: https://zoom-lfx.platform.linuxfoundation.org/meetings/intoto
+[meeting notes]: https://github.com/in-toto/community/tree/main/community-meetings
 [RFC 3339]: https://tools.ietf.org/html/rfc3339
 [URL redirects list]: https://github.com/in-toto/in-toto.io/blob/main/layouts/index.redirects
 [field types]: ../spec/v1/field_types.md


### PR DESCRIPTION
Step 2 of the vetting process in docs/new_predicate_guidelines.md says the maintainers will review the PR at the next maintainers meeting. I went looking for that meeting while preparing a predicate submission, could not find it, and here is what I found instead.

A case-insensitive grep for "meeting" over the repository returns two lines. One sits in docs/motivating_use_case.md, where the word is ordinary English inside a YAML fragment. The other is step 2 itself. GOVERNANCE.md here never mentions a meeting of any kind, so the document naming the forum is also the only document that knows it exists, and it gives no time, no calendar, no channel and no notes.

The community repository does not close the gap either. The Attestations entry in in-toto/community carries a description of the framework and a link to the specification, with no meeting link and no notes link, even though GOVERNANCE.md in that same repository asks each subproject to keep up-to-date meeting notes linked from its page and to report activity in the monthly community meeting. A contributor who does exactly what step 2 says arrives at a forum with no route to it from anywhere in either repository.

The change points step 2 at the forum that governance document does name. Maintainers still review the PR, which was never in question and is left alone. What follows now says subproject activity is reported at the monthly community meeting, the open forum for raising a proposal or asking after the status of one, and links the LFX calendar entry and the community repository's meeting notes.

One thing to settle in review, and I have measured it since opening this rather than leaving it as a guess. The `[meeting notes]` link here lands on community-meetings, and that directory has had no commit since 26 June 2024. Its newest file is `2024.md`, 142 bytes, whose whole body says the minutes moved to HackMD, so the last year file carrying actual minutes is 2023. The HackMD it points at is live, with dated entries running to the 4 September 2026 call. The link works, in the sense that a determined reader gets there, and what that reader sees first is a directory whose most recent real content is the October 2023 minutes. My recommendation is to keep in-toto/community as the durable location and name the HackMD beside it on the same line, which is what `2024.md` already does and what the community GOVERNANCE.md asks for when it tells maintainers to keep notes linked from the subproject page. Pointing the guidelines straight at the HackMD reads cleaner and breaks the day the HackMD moves. Say which you want and I will push it.

It is worth saying what the diff does not do. It does not change who reviews a predicate or how, adds no process, and makes no claim about whether a maintainers meeting happens. It only stops the document sending a reader somewhere they cannot get to.

For whatever it is worth as motivation, the open predicate PRs here suggest the gap is being felt rather than theorised. #496 has been open since October 2025 with a bump asking for review. #552 asked in July to be redirected if predicate review sits somewhere other than where its author was looking. Neither is a complaint about review latency, and I am not making one. Both read to me as people who could not find where the conversation happens, which is the thing the diff is trying to fix.

The hedge I originally closed with has an answer, and it did not come from reading. I went to the meeting. The forum I could not find, the maintainers meeting that step 2 names, is not the one that convenes. The monthly community meeting is, and predicate review is not incidental there: it was the substantive item on 7 August, where the vetted versus community tier discussion happened, and the 4 September agenda carries a predicate review item too. So the sentence this diff swaps in describes where I watched review happen. Happy to adjust the wording.

Edited 2026-08-20. Two things this description said before are corrected above: the meeting-notes link is one hop to a directory that has not been touched since June 2024 rather than to a maintained pointer, and the closing hedge about whether a maintainers meeting still convenes is answered rather than open.

Edited again 2026-08-20 for one date. The directory's most recent real content was described as two years old; the last commit carrying minutes there is 2023-10-06, so it is closer to three.
